### PR TITLE
Show Verify Queue Count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ node_modules
 /functions
 /bombdata/bombhtml
 .env
+.vscode/launch.json
+.vscode/tasks.json
 RunServer.bat

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 /functions
 /bombdata/bombhtml
 .env
+RunServer.bat


### PR DESCRIPTION
Fix for #11 
This change adds a number next to the Verify button showing how many unverified entires exist in the queues you have access to. 

If a user has access to only VerifyCompletions, then they would only see the amount of unverified completions, not the whole queue.

Known minor issue: Takes a couple reloads to update the number. I'm not versed enough in svelte to know how to make a module script dynamically update. Nor could I get the {#await} call to reach the {:then} stage.