### PR TITLE
Change the parse in the MissionPack Upload

### DIFF
--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -15,9 +15,16 @@
 		let trimmed = str.trim();
 		if (isOnlyDigits(trimmed)) return trimmed;
 		else {
-			trimmed = trimmed.replace('https://steamcommunity.com/sharedfiles/filedetails/?id=', '');
-			trimmed = trimmed.substring(0, trimmed.search(/[^0-9]/));
-			if (isOnlyDigits(trimmed)) return trimmed;
+			let url: URL | null = null;
+			try{
+				url = new URL(str);
+			} catch (e : any){
+				return null;
+			}
+			if(url?.hostname !== "steamcommunity.com") return null;
+			let id = url?.searchParams?.get('id')
+			if(id === null) return null;
+			if (isOnlyDigits(id)) return id;
 		}
 		return null;
 	}

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -16,15 +16,20 @@
 		if (isOnlyDigits(trimmed)) return trimmed;
 		else {
 			let url: URL | null = null;
-			try{
+			try {
 				url = new URL(trimmed);
-			} catch (e : any){
+			} catch (e: any) {
 				return null;
 			}
-			if(url?.hostname !== "steamcommunity.com") return null;
-			let id = url?.searchParams?.get('id')
-			if(id === null) return null;
+			if (url?.hostname !== 'steamcommunity.com') return null;
+			let id = url?.searchParams?.get('id');
+			if (id === null) return null;
+			console.log();
 			if (isOnlyDigits(id)) return id;
+			else {
+				let numbers = id.substring(0, id.search(/[^0-9]/));
+				if (isOnlyDigits(numbers)) return numbers;
+			}
 		}
 		return null;
 	}

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -17,7 +17,7 @@
 		else {
 			let url: URL | null = null;
 			try{
-				url = new URL(str);
+				url = new URL(trimmed);
 			} catch (e : any){
 				return null;
 			}


### PR DESCRIPTION
Change the MissionPack ID field to parse the input as a number or a URL that points to a steamcommunity.com hostname.

Current Regex requires a character to occur after the id, which is not guaranteed.