### PR TITLE
Use URL parsing for Mission ID upload

### DIFF
--- a/src/lib/controls/Input.svelte
+++ b/src/lib/controls/Input.svelte
@@ -14,9 +14,11 @@
 	export let sideLabel: boolean = false;
 	export let instantFormat: boolean = true;
 	export let options: any[] | null = null;
+	export let optionalOptions: boolean = false;
 	export let display = (value: any) => value.toString();
 	export let parse = (value: string): any => value;
 	export let validate = (_value: any): boolean | string => true;
+	export let invalid: boolean = false;
 
 	const dispatch = createEventDispatcher();
 	let input: HTMLInputElement;
@@ -30,7 +32,7 @@
 	const handleInput = (e: Event & { currentTarget: EventTarget & HTMLInputElement }) => {
 		displayValue = e.currentTarget.value;
 		let newValue = parse(e.currentTarget.value);
-		if (options !== null) {
+		if (options !== null && !optionalOptions) {
 			let match = false;
 			for (const option of options) {
 				if (newValue === display(option)) {
@@ -49,13 +51,13 @@
 
 	function handleValidity(value: any, showErrors: boolean = true): boolean {
 		const validity = validate(value);
-		if (required) {
-			input.setCustomValidity(typeof validity === 'string' ? validity : validity ? '' : 'Invalid value.');
-			input.reportValidity();
+		if (required || validity !== null) {
+			input.setCustomValidity(typeof validity === 'string' ? validity : validity ? '' : 'Invalid value');
 		}
 
 		if (showErrors) error = input.validationMessage;
 
+		invalid = !(validity === true || validity === '');
 		return validity === true || validity === '';
 	}
 

--- a/src/lib/controls/Input.svelte
+++ b/src/lib/controls/Input.svelte
@@ -19,6 +19,7 @@
 	export let parse = (value: string): any => value;
 	export let validate = (_value: any): boolean | string => true;
 	export let invalid: boolean = false;
+	export let forceValidate: boolean = false;
 
 	const dispatch = createEventDispatcher();
 	let input: HTMLInputElement;
@@ -51,7 +52,7 @@
 
 	function handleValidity(value: any, showErrors: boolean = true): boolean {
 		const validity = validate(value);
-		if (required || validity !== null) {
+		if (required || forceValidate) {
 			input.setCustomValidity(typeof validity === 'string' ? validity : validity ? '' : 'Invalid value');
 		}
 

--- a/src/lib/controls/Input.svelte
+++ b/src/lib/controls/Input.svelte
@@ -58,7 +58,7 @@
 		if (showErrors) error = input.validationMessage;
 
 		invalid = !(validity === true || validity === '');
-		return validity === true || validity === '';
+		return !invalid;
 	}
 
 	onMount(() => handleValidity(value, false));

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -278,7 +278,3 @@ export function checkIfImageExists(url: string, callback: (exists: boolean) => v
 		};
 	}
 }
-
-export function requiredField(): string {
-	return 'Please fill out this field.';
-}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -278,3 +278,7 @@ export function checkIfImageExists(url: string, callback: (exists: boolean) => v
 		};
 	}
 }
+
+export function requiredField(): string {
+	return 'Please fill out this field.';
+}

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -15,9 +15,16 @@
 		let trimmed = str.trim();
 		if (isOnlyDigits(trimmed)) return trimmed;
 		else {
-			trimmed = trimmed.replace('https://steamcommunity.com/sharedfiles/filedetails/?id=', '');
-			trimmed = trimmed.substring(0, trimmed.search(/[^0-9]/));
-			if (isOnlyDigits(trimmed)) return trimmed;
+			let url: URL | null = null;
+			try{
+				url = new URL(str);
+			} catch (e : any){
+				return null;
+			}
+			if(url?.hostname !== "steamcommunity.com") return null;
+			let id = url?.searchParams?.get('id')
+			if(id === null) return null;
+			if (isOnlyDigits(id)) return id;
 		}
 		return null;
 	}

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -9,30 +9,32 @@
 		steamId: ''
 	};
 
-	$: valid = pack.name.length > 0 && pack.steamId.length > 0;
+	let invalid = false;
 
-	function parseSteamId(str: string): string | null {
+	$: valid = !invalid && pack.name.length > 0 && pack.steamId.length > 0;
+
+	function validateSteamId(str: string): string | boolean {
 		let trimmed = str.trim();
-		if (isOnlyDigits(trimmed)) return trimmed;
+		if (isOnlyDigits(trimmed)) return '';
 
 		let url: URL | null = null;
 		try {
 			url = new URL(trimmed);
 		} catch (e: any) {
-			return null;
+			return 'Invalid Steam Workshop URL or Workshop ID.';
 		}
 
-		if (url?.hostname !== 'steamcommunity.com') return null;
+		if (url?.hostname !== 'steamcommunity.com') return 'Invalid Steam Workshop URL or Workshop ID.';
 
 		let id = url?.searchParams?.get('id');
-		if (id === null) return null;
+		if (id === null) return 'Invalid Steam Workshop URL or Workshop ID.';
 
-		if (isOnlyDigits(id)) return id;
+		if (isOnlyDigits(id)) return '';
 
 		id = id.substring(0, id.search(/[^0-9]/));
-		if (isOnlyDigits(id)) return id;
+		if (isOnlyDigits(id)) return '';
 
-		return null;
+		return 'Invalid Steam Workshop URL or Workshop ID';
 	}
 
 	function upload() {
@@ -57,11 +59,11 @@
 <div class="block flex grow">
 	<Input label="Name" id="pack-name" required bind:value={pack.name} />
 	<Input
-		label="Steam ID"
+		label="Steam ID / Workshop URL"
 		id="pack-steam-id"
-		parse={parseSteamId}
-		validate={value => value != null}
-		instantFormat={false}
+		validate={validateSteamId}
+		required
+		bind:invalid
 		bind:value={pack.steamId} />
 </div>
 <div class="block">

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -16,20 +16,15 @@
 		if (isOnlyDigits(trimmed)) return trimmed;
 		else {
 			let url: URL | null = null;
-			try {
+			try{
 				url = new URL(trimmed);
-			} catch (e: any) {
+			} catch (e : any){
 				return null;
 			}
-			if (url?.hostname !== 'steamcommunity.com') return null;
-			let id = url?.searchParams?.get('id');
-			if (id === null) return null;
-			console.log();
+			if(url?.hostname !== "steamcommunity.com") return null;
+			let id = url?.searchParams?.get('id')
+			if(id === null) return null;
 			if (isOnlyDigits(id)) return id;
-			else {
-				let numbers = id.substring(0, id.search(/[^0-9]/));
-				if (isOnlyDigits(numbers)) return numbers;
-			}
 		}
 		return null;
 	}

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -16,15 +16,20 @@
 		if (isOnlyDigits(trimmed)) return trimmed;
 		else {
 			let url: URL | null = null;
-			try{
+			try {
 				url = new URL(trimmed);
-			} catch (e : any){
+			} catch (e: any) {
 				return null;
 			}
-			if(url?.hostname !== "steamcommunity.com") return null;
-			let id = url?.searchParams?.get('id')
-			if(id === null) return null;
+			if (url?.hostname !== 'steamcommunity.com') return null;
+			let id = url?.searchParams?.get('id');
+			if (id === null) return null;
+			console.log();
 			if (isOnlyDigits(id)) return id;
+			else {
+				let numbers = id.substring(0, id.search(/[^0-9]/));
+				if (isOnlyDigits(numbers)) return numbers;
+			}
 		}
 		return null;
 	}

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -17,7 +17,7 @@
 		else {
 			let url: URL | null = null;
 			try{
-				url = new URL(str);
+				url = new URL(trimmed);
 			} catch (e : any){
 				return null;
 			}

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -14,18 +14,24 @@
 	function parseSteamId(str: string): string | null {
 		let trimmed = str.trim();
 		if (isOnlyDigits(trimmed)) return trimmed;
-		else {
-			let url: URL | null = null;
-			try{
-				url = new URL(trimmed);
-			} catch (e : any){
-				return null;
-			}
-			if(url?.hostname !== "steamcommunity.com") return null;
-			let id = url?.searchParams?.get('id')
-			if(id === null) return null;
-			if (isOnlyDigits(id)) return id;
+
+		let url: URL | null = null;
+		try {
+			url = new URL(trimmed);
+		} catch (e: any) {
+			return null;
 		}
+
+		if (url?.hostname !== 'steamcommunity.com') return null;
+
+		let id = url?.searchParams?.get('id');
+		if (id === null) return null;
+
+		if (isOnlyDigits(id)) return id;
+
+		id = id.substring(0, id.search(/[^0-9]/));
+		if (isOnlyDigits(id)) return id;
+
 		return null;
 	}
 

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -10,31 +10,43 @@
 	};
 
 	let invalid = false;
+	let valid = false;
+	let inputtedId = '';
+	$: {
+		pack.steamId = getSteamID(inputtedId);
+		valid = !invalid && pack.name.length > 0 && pack.steamId.length > 0;
+	}
 
-	$: valid = !invalid && pack.name.length > 0 && pack.steamId.length > 0;
-
-	function validateSteamId(str: string): string | boolean {
+	function getSteamID(str: string): string {
 		let trimmed = str.trim();
-		if (isOnlyDigits(trimmed)) return '';
+		if (isOnlyDigits(trimmed)) return trimmed;
 
 		let url: URL | null = null;
 		try {
 			url = new URL(trimmed);
 		} catch (e: any) {
-			return 'Invalid Steam Workshop URL or Workshop ID.';
+			return '';
 		}
 
-		if (url?.hostname !== 'steamcommunity.com') return 'Invalid Steam Workshop URL or Workshop ID.';
+		if (url?.hostname !== 'steamcommunity.com') return '';
 
 		let id = url?.searchParams?.get('id');
-		if (id === null) return 'Invalid Steam Workshop URL or Workshop ID.';
+		if (id === null) return '';
 
-		if (isOnlyDigits(id)) return '';
+		if (isOnlyDigits(id)) return id;
 
 		id = id.substring(0, id.search(/[^0-9]/));
-		if (isOnlyDigits(id)) return '';
+		if (isOnlyDigits(id)) return id;
 
-		return 'Invalid Steam Workshop URL or Workshop ID';
+		return '';
+	}
+
+	function validateSteamID(str: string): string | boolean {
+		let id = getSteamID(str);
+		if (id === '') {
+			return 'Invalid Steam Workshop URL or Workshop ID.';
+		}
+		return '';
 	}
 
 	function upload() {
@@ -61,10 +73,10 @@
 	<Input
 		label="Steam ID / Workshop URL"
 		id="pack-steam-id"
-		validate={validateSteamId}
+		validate={validateSteamID}
 		required
 		bind:invalid
-		bind:value={pack.steamId} />
+		bind:value={inputtedId} />
 </div>
 <div class="block">
 	<button on:click={upload} disabled={!valid}>Upload</button>


### PR DESCRIPTION
Parse Mission ID as int or as a URL. Use parsed URL to get the id paramstring.

Current Regex requires a character after the id numbers. If no character is found, then even a valid string will fail.