### PR TITLE
bugs, replace missions and solves, multi-bomb, mission editing

### DIFF
--- a/src/lib/cards/MissionCardInner.svelte
+++ b/src/lib/cards/MissionCardInner.svelte
@@ -8,7 +8,7 @@
 	const bombs = mission.bombs;
 	const statBomb = new Bomb();
 	statBomb.modules = bombs.map(bomb => bomb.modules).reduce((a, b) => a + b, 0);
-	statBomb.time = Math.max(...bombs.map(bomb => bomb.time));
+	statBomb.time = bombs.map(bomb => bomb.time).reduce((a, b) => a + b, 0);
 	statBomb.strikes = Math.max(...bombs.map(bomb => bomb.strikes));
 	statBomb.widgets = Math.max(...bombs.map(bomb => bomb.widgets));
 </script>

--- a/src/lib/comp/LayoutSearchFilter.svelte
+++ b/src/lib/comp/LayoutSearchFilter.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import Input from '$lib/controls/Input.svelte';
 	import TextArea from '$lib/controls/TextArea.svelte';
-	import { onMount, createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 
 	export let id: string;
 	export let label: string = 'Find:';
 	export let items: { [name: string]: any };
 	export let filterFunc: (itemKey: string, text: string) => boolean;
 	export let searchText: string = '';
+	export let rawSearchText: string = '';
 	export let title: string = '';
 	export let textArea: boolean = false;
 	export let rows: number = 2;
@@ -19,11 +21,11 @@
 
 	const dispatch = createEventDispatcher();
 	let searchField: HTMLInputElement | null;
-	let rawSearchText: string = '';
 
 	function clearSearch() {
 		rawSearchText = '';
 		updateSearch();
+		dispatch('change');
 		searchField?.focus();
 	}
 
@@ -44,12 +46,10 @@
 			} else items[item]?.classList.add('search-filtered-out');
 		});
 		searching = false;
-		dispatch('change');
+		dispatch('input');
 	}
 
-	onMount(() => {
-		searchField = <HTMLInputElement>document.getElementById(id);
-	});
+	if (browser) searchField = <HTMLInputElement>document.getElementById(id);
 </script>
 
 {#if textArea}
@@ -61,6 +61,7 @@
 		sideLabel
 		classes="search-field {classes}"
 		on:input={updateSearch}
+		on:change
 		{autoExpand}
 		{rows}
 		bind:value={rawSearchText} />
@@ -73,6 +74,7 @@
 		sideLabel
 		classes="search-field {classes}"
 		on:input={updateSearch}
+		on:change
 		bind:value={rawSearchText} />
 {/if}
 <div class="search-field-clear dark-invert" on:click={clearSearch} />

--- a/src/lib/home/HomeFiltersMenu.svelte
+++ b/src/lib/home/HomeFiltersMenu.svelte
@@ -33,12 +33,13 @@
 		'Has Needy',
 		'Designed for TP'
 	];
-	let sortOptions = ['Alphabetical', 'Module Count', 'Bomb Time', 'Solves', 'Rule Seeded Mods %'];
+	let sortOptions = ['Alphabetical', 'Module Count', 'Bomb Time', 'Solves', 'Bomb Count', 'Rule Seeded Mods %'];
 	let limitDef: { [k: string]: number[] } = {
 		mods: [1, 600],
-		time: [1, 1500],
+		time: [1, 1600],
 		strk: [1, 150],
 		widg: [0, 40],
+		bmbs: [1, 30],
 		prof: [80]
 	};
 	let checkDef: { [k: string]: boolean } = {
@@ -101,6 +102,7 @@
 		Object.assign(op.numMods, limits['mods']);
 		Object.assign(op.strikes, limits['strk']);
 		Object.assign(op.widgets, limits['widg']);
+		Object.assign(op.numBombs, limits['bmbs']);
 		Object.assign(op.profPerc, limits['prof']);
 		Object.assign(op.modules, profile);
 		dispatch('update', {
@@ -380,6 +382,29 @@
 					on:change={setOption} />
 			</div>
 			<div class="vspace" />
+			<span>Bombs</span>
+			<div class="flex">
+				<Input
+					required
+					name="option-bmsl"
+					id="option-bmsl"
+					bind:value={limits['bmbs'][0]}
+					classes="limits"
+					parse={parseInteger}
+					validate={intnan}
+					on:change={setOption} />
+				<span class="through" />
+				<Input
+					required
+					name="option-bmsu"
+					id="option-bmsu"
+					bind:value={limits['bmbs'][1]}
+					classes="limits"
+					parse={parseInteger}
+					validate={intnan}
+					on:change={setOption} />
+			</div>
+			<div class="vspace" />
 			<Checkbox
 				id="option-persist-searchtext"
 				label="Persist Query"
@@ -614,7 +639,7 @@
 	}
 	.center-divider {
 		width: 0;
-		height: 285px;
+		height: 310px;
 		border: 1px solid var(--light-text-color);
 		margin: 0 0.8em;
 	}

--- a/src/lib/home/HomeFiltersMenu.svelte
+++ b/src/lib/home/HomeFiltersMenu.svelte
@@ -42,7 +42,8 @@
 		prof: [80]
 	};
 	let checkDef: { [k: string]: boolean } = {
-		'sort-reverse': false
+		'sort-reverse': false,
+		'persist-searchtext': true
 	};
 	let opExplain =
 		'Expert: A minimum percent of mods in the mission must be found in the "Yes" list\n' +
@@ -379,6 +380,12 @@
 					on:change={setOption} />
 			</div>
 			<div class="vspace" />
+			<Checkbox
+				id="option-persist-searchtext"
+				label="Persist Query"
+				bind:checked={checks['persist-searchtext']}
+				sideLabel
+				on:change={setOption} />
 		</div>
 		<div class="center-divider" />
 		<div>

--- a/src/lib/home/HomeFiltersMenu.svelte
+++ b/src/lib/home/HomeFiltersMenu.svelte
@@ -416,35 +416,36 @@
 		<div>
 			<table>
 				{#each hasOptions as op, index}
+					{@const dashOp = toDashed(op)}
 					<tr>
 						<td class="row-header nowrap">{op}</td>
 						<td>
 							<RadioButton
-								id={`option-${toDashed(op)}-yes}`}
+								id="option-{dashOp}-yes"
 								label="Yes"
 								value={MustHave.Yes}
 								sideLabel
-								name={`option-${toDashed(op)}`}
-								bind:group={mustHaves[toDashed(op)]}
+								name="option-{dashOp}"
+								bind:group={mustHaves[dashOp]}
 								on:change={setOption} />
 						</td>
 						<td>
 							<RadioButton
-								id={`option-${toDashed(op)}-no}`}
+								id="option-{dashOp}-no"
 								label="No"
 								value={MustHave.No}
 								sideLabel
-								name={`option-${toDashed(op)}`}
-								bind:group={mustHaves[toDashed(op)]}
+								name="option-{dashOp}"
+								bind:group={mustHaves[dashOp]}
 								on:change={setOption} /></td>
 						<td>
 							<RadioButton
-								id={`option-${toDashed(op)}-either}`}
+								id="option-{dashOp}-either"
 								label="Either"
 								value={MustHave.Either}
 								sideLabel
-								name={`option-${toDashed(op)}`}
-								bind:group={mustHaves[toDashed(op)]}
+								name="option-{dashOp}"
+								bind:group={mustHaves[dashOp]}
 								on:change={setOption} /></td>
 					</tr>
 				{/each}

--- a/src/lib/home/HomeSearchBar.svelte
+++ b/src/lib/home/HomeSearchBar.svelte
@@ -108,6 +108,8 @@
 				strk > options.strikes[1] ||
 				widg < options.widgets[0] ||
 				widg > options.widgets[1] ||
+				ms.bombs.length < options.numBombs[0] ||
+				ms.bombs.length > options.numBombs[1] ||
 				!meetsHave(numCompletions(ms, false) > 0, options.mustHave['has-team/efm-solve']) ||
 				!meetsHave(ms.tpSolve, options.mustHave['has-tp-solve']) ||
 				!meetsHave(ms.designedForTP, options.mustHave['designed-for-tp']) ||
@@ -151,7 +153,7 @@
 	}
 
 	function timeSum(m: Mission) {
-		return Math.max(...m.bombs.map(b => b.time));
+		return m.bombs.map(b => b.time).reduce((a, b) => a + b, 0);
 	}
 	function modSum(m: Mission) {
 		return m.bombs.map(b => b.modules).reduce((a, b) => a + b, 0);
@@ -169,7 +171,7 @@
 		a: Mission,
 		b: Mission,
 		primary: (m: Mission) => number,
-		secondary: (m: Mission) => number
+		secondary: (m: Mission) => number | string
 	): boolean {
 		let diff = primary(a) - primary(b);
 		if (diff > 0) return true;
@@ -213,6 +215,9 @@
 					break;
 				case 'solves':
 					missions.sort((a, b) => (compare(a, b, numCompletions, timeSum) != reverse ? 1 : -1));
+					break;
+				case 'bomb-count':
+					missions.sort((a, b) => (compare(a, b, m => m.bombs.length, timeSum) != reverse ? 1 : -1));
 					break;
 				case 'rule-seeded-mods-%':
 					fastSort = delayModulesCalculation(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,13 +105,13 @@ export type QueueItem = MissionQueueItem | CompletionQueueItem | MissionPackQueu
 
 export interface MissionQueueItem {
 	type: 'mission';
-	mission: ID<MissionWithPack>;
+	mission: Omit<ID<MissionWithPack>, 'bombs'> & { bombs: ID<Bomb>[] };
 }
 
 export interface CompletionQueueItem {
 	type: 'completion';
 	completion: ID<Completion>;
-	mission: ID<Mission>;
+	mission: Omit<ID<Mission>, 'completions'> & { completions: ID<Completion>[] };
 }
 
 export interface MissionPackQueueItem {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,7 +105,7 @@ export type QueueItem = MissionQueueItem | CompletionQueueItem | MissionPackQueu
 
 export interface MissionQueueItem {
 	type: 'mission';
-	mission: ID<Mission>;
+	mission: ID<MissionWithPack>;
 }
 
 export interface CompletionQueueItem {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,9 +87,10 @@ export class HomeOptions {
 	checks: { [k: string]: boolean } = {};
 	modules: { [k: string]: any } = {};
 	numMods = [1, 600];
-	time = [1, 1500];
+	time = [1, 1600];
 	strikes = [1, 150];
 	widgets = [0, 40];
+	numBombs = [1, 30];
 	profPerc = [80];
 	mustHave: { [k: string]: MustHave } = {};
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -129,12 +129,13 @@ function findMatchingBrackets(str: string, left: string, right: string): number[
 // example: thing one && aaa || bbb && !!ccc
 // which means: ("thing one" and "aaa") or ("bbb" and not "ccc")
 // brackets are supported too: [[ thing one || aaa ]] && [[ bbb || !!ccc ]]
+export const reservedSearchStrings = ['[[', ']]', '&&', '||', '!!'];
 export function evaluateLogicalStringSearch(expression: string, searchWhat: string): boolean {
-	const left = '[[';
-	const right = ']]';
-	const aand = '&&';
-	const oor = '||';
-	const nnot = '!!';
+	let left = reservedSearchStrings[0];
+	let right = reservedSearchStrings[1];
+	let aand = reservedSearchStrings[2];
+	let oor = reservedSearchStrings[3];
+	let nnot = reservedSearchStrings[4];
 	const expr = expression.trim();
 	let exprAfter = expr;
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,5 +1,5 @@
 import type * as client from '@prisma/client';
-import type { Bomb, FrontendUser, Mission, Permission, Pool } from './types';
+import type { Bomb, FrontendUser, ID, Mission, Permission, Pool } from './types';
 import { redirect, error } from '@sveltejs/kit';
 import type { RepoModule } from './repo';
 
@@ -78,7 +78,7 @@ export function forbidden(locals: App.Locals) {
 	return error(403, 'You do not have permission for to do that.');
 }
 
-export function fixPools<T>(mission: T & { bombs: client.Bomb[] }): T & { bombs: Bomb[] } {
+export function fixPools<T>(mission: T & { bombs: client.Bomb[] }): T & { bombs: ID<Bomb>[] } {
 	return {
 		...mission,
 		bombs: mission.bombs.map(bomb => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,7 +20,7 @@
 			{/if}
 
 			<div style="margin-left: auto;">
-				<a href="/user/{user.username}">
+				<a href="/user/{encodeURIComponent(user.username)}">
 					<UserCard {user} />
 				</a>
 			</div>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -14,7 +14,11 @@ export const load: PageServerLoad = async function () {
 			designedForTP: true,
 			tpSolve: true,
 			factory: true,
-			completions: true
+			completions: {
+				where: {
+					verified: true
+				}
+			}
 		}
 	});
 

--- a/src/routes/json/missions/+server.ts
+++ b/src/routes/json/missions/+server.ts
@@ -11,7 +11,11 @@ export async function GET() {
 			authors: true,
 			bombs: true,
 			tpSolve: true,
-			completions: true
+			completions: {
+				where: {
+					verified: true
+				}
+			}
 		}
 	});
 	let result = JSON.stringify(

--- a/src/routes/json/missionsreduced/+server.ts
+++ b/src/routes/json/missionsreduced/+server.ts
@@ -13,7 +13,11 @@ export async function GET() {
 			bombs: true,
 			designedForTP: true,
 			tpSolve: true,
-			completions: true
+			completions: {
+				where: {
+					verified: true
+				}
+			}
 		}
 	});
 

--- a/src/routes/mission/[...mission]/+page.server.ts
+++ b/src/routes/mission/[...mission]/+page.server.ts
@@ -16,7 +16,11 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			name: true,
 			authors: true,
 			verified: true,
-			bombs: true,
+			bombs: {
+				orderBy: {
+					id: 'asc'
+				}
+			},
 			completions: {
 				where: {
 					verified: true

--- a/src/routes/mission/[...mission]/+page.svelte
+++ b/src/routes/mission/[...mission]/+page.svelte
@@ -20,7 +20,7 @@
 			if (mod.BossStatus != undefined) classes += ' boss';
 			if (mod.Quirks != undefined) classes += ' quirks';
 			if (mod.Type == 'Needy') classes += ' needy';
-		}
+		} else classes += ' border';
 		return classes;
 	}
 
@@ -46,8 +46,15 @@
 {#if !mission.verified}
 	<div class="block centered not-verified">This mission has not been verified.</div>
 {/if}
-{#if mission.factory !== null}
-	<div class="block centered">Factory: {mission.factory}</div>
+{#if mission.factory !== null || mission.designedForTP}
+	<div class="block hstack">
+		{#if mission.factory !== null}
+			<span>Factory: {mission.factory}</span>
+		{/if}
+		{#if mission.designedForTP}
+			<span class="designed-for-tp">Designed for TP</span>
+		{/if}
+	</div>
 {/if}
 <div class="main-content">
 	<div class="bombs">
@@ -62,9 +69,6 @@
 					bomb.widgets,
 					'Widget'
 				)}
-				{#if mission.designedForTP}
-					· <span class="designed-for-tp">Designed for TP</span>
-				{/if}
 			</div>
 			<div class="pools">
 				{#each bomb.pools as pool}
@@ -119,6 +123,11 @@
 	.hspace {
 		width: 100px;
 	}
+	.hstack {
+		display: flex;
+		justify-content: center;
+		gap: 20px;
+	}
 
 	.bombs {
 		display: flex;
@@ -161,6 +170,10 @@
 	span.needy {
 		background-color: #0000ff66 !important;
 	}
+	.pool.border {
+		border: 2px dashed var(--textbox-background);
+	}
+
 	span.first-solve {
 		background-color: hsl(43, 74%, 70%);
 		color: black;

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -22,7 +22,11 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			name: true,
 			authors: true,
 			verified: true,
-			bombs: true,
+			bombs: {
+				orderBy: {
+					id: 'asc'
+				}
+			},
 			completions: {
 				where: {
 					verified: true

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -52,7 +52,8 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 
 	const packs = await client.missionPack.findMany({
 		select: {
-			name: true
+			name: true,
+			id: true
 		}
 	});
 

--- a/src/routes/mission/[mission]/edit/+page.svelte
+++ b/src/routes/mission/[mission]/edit/+page.svelte
@@ -30,6 +30,7 @@
 	for (const bomb of mission.bombs) {
 		bomb.pools.sort((a, b) => a.modules.join().localeCompare(b.modules.join()));
 	}
+	mission.completions.sort((a, b) => b.time - a.time);
 	setOriginalMission();
 
 	$: modified = !equal(mission, originalMission);
@@ -209,7 +210,15 @@
 		{#each mission.completions as completion}
 			<div class="block flex column relative">
 				<Input label="Proof" id="completion-proof" bind:value={completion.proofs} />
-				<Input label="Time" id="completion-time" bind:value={completion.time} parse={parseTime} display={formatTime} />
+				<Input
+					label="Time"
+					id="completion-time"
+					validate={value => value != null}
+					display={value => formatTime(value, value % 1 != 0)}
+					instantFormat={false}
+					placeholder="1:23:45.67"
+					bind:value={completion.time}
+					parse={parseTime} />
 				<Input
 					label="Team"
 					id="completion-team"

--- a/src/routes/mission/[mission]/edit/+page.svelte
+++ b/src/routes/mission/[mission]/edit/+page.svelte
@@ -4,7 +4,15 @@
 	import NoContent from '$lib/comp/NoContent.svelte';
 	import type { RepoModule } from '$lib/repo';
 	import Select from '$lib/controls/Select.svelte';
-	import { Permission, type Completion, type ID, type Mission, type MissionPack, type Bomb, Pool } from '$lib/types';
+	import {
+		Permission,
+		type Completion,
+		type ID,
+		type Mission,
+		type Bomb,
+		Pool,
+		type MissionPackSelection
+	} from '$lib/types';
 	import { displayStringList, formatTime, hasPermission, parseInteger, parseList, parseTime } from '$lib/util';
 	import equal from 'fast-deep-equal';
 	import { sortBombs } from '../../_shared';
@@ -16,7 +24,7 @@
 
 	let mission: EditMission & { verified: boolean } = data.mission;
 	let missionNames: string[] = data.missionNames;
-	let packs: Pick<ID<MissionPack>, 'id' | 'name'>[] = data.packs;
+	let packs: MissionPackSelection[] = data.packs;
 	let modules: Record<string, RepoModule> | null = data.modules;
 
 	sortBombs(mission, modules);
@@ -113,6 +121,8 @@
 		label="Mission Pack"
 		id="mission-pack"
 		bind:value={mission.missionPack}
+		required
+		instantFormat={false}
 		options={packs}
 		display={pack => pack.name}
 		validate={value => value !== null} />

--- a/src/routes/mission/[mission]/edit/+page.svelte
+++ b/src/routes/mission/[mission]/edit/+page.svelte
@@ -207,21 +207,24 @@
 	</div>
 	<div class="flex column">
 		<div class="block header">Solves</div>
-		{#each mission.completions as completion}
+		{#each mission.completions as completion, ci}
 			<div class="block flex column relative">
 				<Input label="Proof" id="completion-proof" bind:value={completion.proofs} />
-				<Input
-					label="Time"
-					id="completion-time"
-					validate={value => value != null}
-					display={value => formatTime(value, value % 1 != 0)}
-					instantFormat={false}
-					placeholder="1:23:45.67"
-					bind:value={completion.time}
-					parse={parseTime} />
+				<div class="hstack">
+					<Input
+						label="Time"
+						id="completion-time-{ci}"
+						validate={value => value != null}
+						display={value => formatTime(value, value % 1 != 0)}
+						instantFormat={false}
+						placeholder="1:23:45.67"
+						bind:value={completion.time}
+						parse={parseTime} />
+					<Checkbox id="completion-first-{ci}" sideLabel label="First" bind:checked={completion.first} />
+				</div>
 				<Input
 					label="Team"
-					id="completion-team"
+					id="completion-team-{ci}"
 					bind:value={completion.team}
 					parse={value => value.split(',').map(person => person.trim())}
 					display={list => list.join(', ')} />
@@ -277,6 +280,11 @@
 	}
 	.hspace {
 		width: 20px;
+	}
+	.hstack {
+		display: flex;
+		align-items: flex-end;
+		gap: 10px;
 	}
 
 	.pools {

--- a/src/routes/mission/[mission]/edit/_types.ts
+++ b/src/routes/mission/[mission]/edit/_types.ts
@@ -1,9 +1,9 @@
-import type { ID, Mission, Completion, MissionPack, Bomb } from '$lib/types';
+import type { ID, Mission, Completion, Bomb, MissionPackSelection } from '$lib/types';
 
 export type EditMission = Omit<ID<Mission>, 'completions' | 'bombs'> & {
 	bombs: ID<Bomb>[];
 	completions: ID<Completion>[];
-	missionPack: Pick<ID<MissionPack>, 'id' | 'name'>;
+	missionPack: MissionPackSelection;
 	variantOf: string;
 	variant: number | null;
 };

--- a/src/routes/solvers/+page.server.ts
+++ b/src/routes/solvers/+page.server.ts
@@ -14,6 +14,9 @@ export const load: PageServerLoad = async function () {
 			},
 			team: true,
 			solo: true
+		},
+		where: {
+			verified: true
 		}
 	});
 

--- a/src/routes/solvers/+page.svelte
+++ b/src/routes/solvers/+page.svelte
@@ -18,7 +18,7 @@
 	<b class="block">EFM</b>
 	{#each completers as completer, index}
 		<div class="block">{index + 1}</div>
-		<div class="block"><a href="/user/{completer.name}">{completer.name}</a></div>
+		<div class="block"><a href="/user/{encodeURIComponent(completer.name)}">{completer.name}</a></div>
 		<div class="block">{completer.distinct}</div>
 		<div class="block">{completer.defuser + completer.expert + completer.efm}</div>
 		<div class="block">{completer.defuser}</div>

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -26,7 +26,7 @@
 	</div>
 </div>
 {#if section == 'mission'}
-	<MissionSection {packs} {authorNames} />
+	<MissionSection {missionNames} {authorNames} {packs} />
 {:else if section == 'missionpack'}
 	<MissionPackSection />
 {:else}

--- a/src/routes/upload/_CompletionSection.svelte
+++ b/src/routes/upload/_CompletionSection.svelte
@@ -130,7 +130,7 @@
 		{#each proofs as proof, i}
 			<div class="dynamicBlock">
 				<Input
-					id="proof"
+					id="proof-{i}"
 					type="url"
 					label="Proof #{i + 1}"
 					placeholder="https://ktane.timwi.de"
@@ -157,7 +157,7 @@
 		{#each team as member, index}
 			<div class="dynamicBlock">
 				<Input
-					id="member"
+					id="member-{index}"
 					type="text"
 					label={index == 0 ? 'Defuser' : 'Expert'}
 					optionalOptions={true}

--- a/src/routes/upload/_CompletionSection.svelte
+++ b/src/routes/upload/_CompletionSection.svelte
@@ -104,7 +104,9 @@
 			body: JSON.stringify({ completion, missionName })
 		})
 			.then(response => {
-				if (response.ok) {
+				if (response.status == 202) {
+					toast.success('Solve REPLACEMENT uploaded successfully!');
+				} else if (response.ok) {
 					toast.success('Solve uploaded successfully!');
 				} else {
 					toast.error('Solve failed to upload.');

--- a/src/routes/upload/_MissionSection.svelte
+++ b/src/routes/upload/_MissionSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Input from '$lib/controls/Input.svelte';
+	import Select from '$lib/controls/Select.svelte';
 	import MissionCard from '$lib/cards/MissionCard.svelte';
 	import { Bomb, Pool, type MissionPackSelection, type MissionWithPack } from '$lib/types';
 	import { reservedSearchStrings } from '$lib/util';
@@ -37,7 +38,7 @@
 					authors: [],
 					designedForTP: false,
 					tpSolve: false,
-					factory: '',
+					factory: null,
 					missionPack: null
 				};
 
@@ -64,18 +65,21 @@
 					const count = parseInt(match[2]);
 
 					const modules = match[1].split(', ');
-					// If the sources are listed, update the "module" to include the source.
-					const sources = match[3]?.split(', ');
-					if (sources !== undefined && sources.length === 1) {
-						const source = sources[0] == 'Modded' ? 'MODS' : 'VANILLA';
-						modules[0] = `ALL_${source}_${modules[0].substring(4)}`;
-					}
+					if (!modules[0].toLowerCase().startsWith('multiple bombs')) {
+						// If the sources are listed, update the "module" to include the source.
+						const sources = match[3]?.split(', ');
+						if (sources !== undefined && sources.length === 1) {
+							const source = sources[0] == 'Modded' ? 'MODS' : 'VANILLA';
+							modules[0] = `ALL_${source}_${modules[0].substring(4)}`;
+						}
 
-					bomb.pools.push(new Pool(modules, count));
-					bomb.modules += count;
+						bomb.pools.push(new Pool(modules, count));
+						bomb.modules += count;
+					}
 				}
 
 				mission.bombs.push(bomb);
+				if (mission.bombs.length > 1) mission.factory = 'Sequence';
 			} else if (line.startsWith('[WidgetGenerator] Added widget: ') && bomb !== null) {
 				bomb.widgets++;
 			} else if (line.startsWith('[Tweaks] LFAEvent ') && mission !== null) {
@@ -174,19 +178,26 @@
 						<Input
 							name="Authors"
 							label="Authors"
-							id="mission-authors"
+							id="mission-authors-{i}"
 							options={authorNames}
 							optionalOptions={true}
 							bind:value={mission.authors} />
 						<Input
 							name="Mission Pack"
 							label="Mission Pack"
-							id="mission-pack"
+							id="mission-pack-{i}"
 							bind:value={mission.missionPack}
 							options={packs}
 							display={pack => (pack === null ? '' : pack.name)}
 							validate={pack => pack !== null}
 							required={selectedMissions[i]} />
+						{#if mission.bombs.length > 1}
+							<Select
+								label="Factory"
+								id="mission-factory-{i}"
+								bind:value={mission.factory}
+								options={['Static', 'Sequence']} />
+						{/if}
 						<Checkbox id="designed-for-tp-{i}" label="Designed for TP" bind:checked={mission.designedForTP} sideLabel />
 					</div>
 				</div>

--- a/src/routes/upload/_MissionSection.svelte
+++ b/src/routes/upload/_MissionSection.svelte
@@ -195,6 +195,7 @@
 							options={packs}
 							display={pack => (pack === null ? '' : pack.name)}
 							validate={pack => pack !== null}
+							instantFormat={false}
 							required={selectedMissions[i]} />
 						{#if mission.bombs.length > 1}
 							<Select

--- a/src/routes/upload/_MissionSection.svelte
+++ b/src/routes/upload/_MissionSection.svelte
@@ -203,7 +203,7 @@
 				</div>
 			{/each}
 		</div>
-		{#if Object.values(selectedMissions).some(a => a) && Object.values(selectedMissions).every((e, i) => e != missionNameError[i])}
+		{#if Object.values(selectedMissions).some(a => a) && Object.values(selectedMissions).every((e, i) => !(e && missionNameError[i]))}
 			<div class="block">
 				<button type="submit"
 					>Upload Mission{Object.values(selectedMissions).filter(a => a).length == 1 ? '' : 's'}</button>

--- a/src/routes/upload/_types.ts
+++ b/src/routes/upload/_types.ts
@@ -1,0 +1,3 @@
+import type { MissionWithPack } from '$lib/types';
+
+export type ReplaceableMission = MissionWithPack & { replace: boolean };

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -1,9 +1,9 @@
 import client from '$lib/client';
-import type { MissionWithPack } from '$lib/types';
 import { error, type RequestEvent } from '@sveltejs/kit';
+import type { ReplaceableMission } from '../_types';
 
 export async function POST({ request }: RequestEvent) {
-	const missions: MissionWithPack[] = await request.json();
+	const missions: ReplaceableMission[] = await request.json();
 	if (missions.some(m => m.missionPack === null)) {
 		throw error(400, 'Mission pack is required');
 	}
@@ -11,7 +11,7 @@ export async function POST({ request }: RequestEvent) {
 	for (const mission of missions) {
 		await client.mission.create({
 			data: {
-				name: mission.name,
+				name: (mission.replace ? '[[UPDATE]] ' : '') + mission.name,
 				authors: mission.authors,
 				bombs: {
 					create: mission.bombs.map(bomb => {
@@ -21,6 +21,7 @@ export async function POST({ request }: RequestEvent) {
 						};
 					})
 				},
+				factory: mission.factory,
 				designedForTP: mission.designedForTP,
 				missionPackId: mission.missionPack?.id,
 				verified: false

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -33,7 +33,8 @@ export const load = async function ({ params }: any) {
 		where: {
 			team: {
 				has: params.user
-			}
+			},
+			verified: true
 		}
 	});
 

--- a/src/routes/user/[user]/+page.svelte
+++ b/src/routes/user/[user]/+page.svelte
@@ -44,7 +44,7 @@
 		});
 
 		if (response.ok) {
-			location.href = `/user/${newUsername}`;
+			location.href = `/user/${encodeURIComponent(newUsername)}`;
 			return;
 		}
 

--- a/src/routes/user/rename/+server.ts
+++ b/src/routes/user/rename/+server.ts
@@ -70,5 +70,5 @@ export const POST: RequestHandler = async function ({ locals, request }) {
 		});
 	}
 
-	throw redirect(301, `/user/${username}`);
+	throw redirect(301, `/user/${encodeURIComponent(username)}`);
 };

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -14,7 +14,7 @@
 
 <h1 class="header">Users</h1>
 {#each users as user}
-	<a href="user/{user.username}">
+	<a href="user/{encodeURIComponent(user.username)}">
 		<UserCard {user} />
 	</a>
 {/each}

--- a/src/routes/verify/+page.server.ts
+++ b/src/routes/verify/+page.server.ts
@@ -2,8 +2,6 @@ import client from '$lib/client';
 import type { CompletionQueueItem, MissionQueueItem, QueueItem } from '$lib/types';
 import { Permission, type MissionPackQueueItem } from '$lib/types';
 import { fixPools, forbidden, hasAnyPermission, hasPermission, onlyUnique } from '$lib/util';
-import type { ServerLoadEvent } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
 
 export const load = async function ({ parent, locals }: any) {
 	const { user } = await parent();
@@ -23,8 +21,19 @@ export const load = async function ({ parent, locals }: any) {
 				id: true,
 				name: true,
 				authors: true,
-				bombs: true,
-				factory: true
+				bombs: {
+					orderBy: {
+						id: 'asc'
+					}
+				},
+				designedForTP: true,
+				factory: true,
+				missionPack: {
+					select: {
+						id: true,
+						name: true
+					}
+				}
 			}
 		});
 
@@ -35,7 +44,6 @@ export const load = async function ({ parent, locals }: any) {
 					mission: {
 						...fixPools(mission),
 						completions: [],
-						designedForTP: false,
 						tpSolve: false
 					}
 				} as MissionQueueItem;

--- a/src/routes/verify/+page.server.ts
+++ b/src/routes/verify/+page.server.ts
@@ -75,7 +75,9 @@ export const load = async function ({ parent, locals }: any) {
 				mission: {
 					include: {
 						bombs: true,
-						completions: true
+						completions: {
+							where: { verified: true }
+						}
 					}
 				}
 			}

--- a/src/routes/verify/+page.svelte
+++ b/src/routes/verify/+page.svelte
@@ -46,7 +46,14 @@
 	{#each queue as item, index (item)}
 		<div class="item {item.type}">
 			{#if item.type === 'mission'}
-				<MissionCard mission={item.mission} />
+				<div>
+					<MissionCard mission={item.mission} />
+					{#if item.mission.name.startsWith('[[UPDATE]] ')}
+						<div class="block red">
+							This would update the parameters of the mission: {item.mission.name.substring(11)}
+						</div>
+					{/if}
+				</div>
 			{:else if item.type === 'completion'}
 				<CompletionCard completion={item.completion} />
 				<MissionCard mission={item.mission} />
@@ -76,5 +83,8 @@
 
 	.item.completion {
 		grid-template-columns: 1fr 1fr auto;
+	}
+	.block.red {
+		color: red;
 	}
 </style>

--- a/src/routes/verify/item/+server.ts
+++ b/src/routes/verify/item/+server.ts
@@ -13,15 +13,65 @@ export const POST: RequestHandler = async function ({ locals, request }: Request
 			}
 
 			if (accept) {
-				await client.mission.update({
-					where: {
-						id: item.mission.id
-					},
-					data: {
-						verified: true
+				if (item.mission.name.startsWith('[[UPDATE]] ')) {
+					let name = item.mission.name.substring(11);
+					//find mission to be updated
+					let selected = await client.mission.findFirst({
+						where: {
+							name: {
+								equals: name,
+								mode: 'insensitive'
+							}
+						},
+						select: {
+							id: true
+						}
+					});
+					try {
+						//delete bomb records from mission being updated
+						await client.bomb.deleteMany({ where: { missionId: selected?.id } });
+						//update mission with parameters copied from queue item
+						await client.mission.update({
+							where: {
+								id: selected?.id
+							},
+							data: {
+								authors: item.mission.authors,
+								bombs: {
+									//create new bomb records matching the queue item's bombs
+									create: item.mission.bombs.map(bomb => ({
+										modules: bomb.modules,
+										time: bomb.time,
+										strikes: bomb.strikes,
+										widgets: bomb.widgets,
+										pools: JSON.parse(JSON.stringify(bomb.pools))
+									}))
+								},
+								factory: item.mission.factory,
+								missionPackId: item.mission.missionPack?.id,
+								name: name,
+								designedForTP: item.mission.designedForTP
+							}
+						});
+						//delete queue item in database entirely
+						await client.bomb.deleteMany({ where: { missionId: item.mission.id } });
+						await client.mission.delete({ where: { id: item.mission.id } });
+					} catch (e) {
+						throw e;
 					}
-				});
+				} else {
+					//accepted - make queue item visible (verified)
+					await client.mission.update({
+						where: {
+							id: item.mission.id
+						},
+						data: {
+							verified: true
+						}
+					});
+				}
 			} else {
+				//rejected - delete queue item entirely
 				await client.bomb.deleteMany({ where: { missionId: item.mission.id } });
 				await client.mission.delete({ where: { id: item.mission.id } });
 			}

--- a/src/routes/verify/item/+server.ts
+++ b/src/routes/verify/item/+server.ts
@@ -5,7 +5,7 @@ import { forbidden, hasPermission } from '$lib/util';
 import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async function ({ locals, request }: RequestEvent) {
-	const { accept, item }: { accept: boolean; item: QueueItem } = await request.json();
+	const { accept, item, replaceId }: { accept: boolean; item: QueueItem; replaceId: number } = await request.json();
 	switch (item.type) {
 		case 'mission':
 			if (!hasPermission(locals.user, Permission.VerifyMission)) {
@@ -38,14 +38,8 @@ export const POST: RequestHandler = async function ({ locals, request }: Request
 							data: {
 								authors: item.mission.authors,
 								bombs: {
-									//create new bomb records matching the queue item's bombs
-									create: item.mission.bombs.map(bomb => ({
-										modules: bomb.modules,
-										time: bomb.time,
-										strikes: bomb.strikes,
-										widgets: bomb.widgets,
-										pools: JSON.parse(JSON.stringify(bomb.pools))
-									}))
+									//connect new bomb records to existing mission
+									connect: item.mission.bombs.map(bomb => ({ ['id']: bomb.id }))
 								},
 								factory: item.mission.factory,
 								missionPackId: item.mission.missionPack?.id,
@@ -53,8 +47,20 @@ export const POST: RequestHandler = async function ({ locals, request }: Request
 								designedForTP: item.mission.designedForTP
 							}
 						});
+						//connect existing mission to new bomb records
+						item.mission.bombs.forEach(async b => {
+							await client.bomb.update({
+								where: {
+									id: b.id
+								},
+								data: {
+									mission: {
+										connect: { id: item.mission.id }
+									}
+								}
+							});
+						});
 						//delete queue item in database entirely
-						await client.bomb.deleteMany({ where: { missionId: item.mission.id } });
 						await client.mission.delete({ where: { id: item.mission.id } });
 					} catch (e) {
 						throw e;
@@ -92,15 +98,30 @@ export const POST: RequestHandler = async function ({ locals, request }: Request
 						}
 					})) === null;
 
-				await client.completion.update({
-					where: {
-						id: item.completion.id
-					},
-					data: {
-						verified: true,
-						first
-					}
-				});
+				if (replaceId >= 0) {
+					await client.completion.update({
+						where: {
+							id: replaceId
+						},
+						data: {
+							team: item.completion.team,
+							time: item.completion.time,
+							solo: item.completion.solo,
+							proofs: item.completion.proofs
+						}
+					});
+					await client.completion.delete({ where: { id: item.completion.id } });
+				} else {
+					await client.completion.update({
+						where: {
+							id: item.completion.id
+						},
+						data: {
+							verified: true,
+							first
+						}
+					});
+				}
 			} else {
 				await client.completion.delete({ where: { id: item.completion.id } });
 			}


### PR DESCRIPTION
1.  Unverified solves do not affect the statistics on missions cards or a user's solves stats #85 
2.  home page remembers your search text (option to turn that off in the filter menu) #79 
3. Uploading of multiple bomb missions now works, example logfile attached containing 4 missions (1 of which has an invalid name and there should be error message telling you so)
4. ability to sort and filter by number of bombs on a mission
5. the order the bombs are listed (for multi-bomb missions) on the mission page should always stay the same even if you edit the bomb pools (it didn't before)
6. Renaming users with special characters like `/\()*&?` are allowed and the link to their page is correctly encoded in the URL like `/user/Tim%5C` for a name called `Tim\`, see [discord discussion](https://discord.com/channels/887088776818602055/1004869408734335056/1057478827707736094)
7. Uploading a mission with the same name as an existing one will replace the mission's parameters, bombs, and modules if accepted. Use the one called Caitlin Bomb in the attached file (modify it's pools however you want in Notepad++ to test that it replaces the mission information), see [discord discussion](https://discord.com/channels/887088776818602055/887088777409986572/1056125006070960178)
8. Pools are easier to see and distinguish with new dashed border only on pools that have multiple modules in them.
9. In the mission edit page, solves are now listed in the same order as they are listed on the actual mission page.
10. Uploading a replacement solve, see [discord discussion](https://discord.com/channels/887088776818602055/1004869408734335056/1056682708065079356)
11. The "First" attribute of a solve can now be edited in the mission edit page (changes which one is highlighted in yellow). I know radio buttons would be better than checkboxes for this, but that is **much** more code to implement because radio buttons don't have a "checked" attribute and this is an extremely rare thing to change.
12. sum of bomb times is now correct for most bombs, see #52   (a future pull request will add a database entry for global time and global strikes)

[TestMissions.txt](https://github.com/samfundev/KTANE-Bombs/files/10369760/TestMissions.txt)