### PR TITLE
Logfile uploads

### DIFF
--- a/importer/import.js
+++ b/importer/import.js
@@ -13,10 +13,12 @@ const { PrismaClient } = pkg;
 			create: {
 				name: pack.name,
 				steamId: pack.steamID,
+				dateAdded: pack.dateAdded,
 				verified: pack.verified
 			},
 			update: {
 				steamId: pack.steamID,
+				dateAdded: pack.dateAdded,
 				verified: pack.verified
 			},
 			where: {
@@ -37,6 +39,7 @@ const { PrismaClient } = pkg;
 				timeMode: mission.timeMode,
 				variant: mission.variant,
 				verified: mission.verified,
+				dateAdded: mission.dateAdded,
 				missionPackId: missionPack.id
 			});
 			for (const completion of mission.completions) {
@@ -76,6 +79,7 @@ const { PrismaClient } = pkg;
 					timeMode: mission.timeMode,
 					variant: mission.variant,
 					verified: mission.verified,
+					dateAdded: mission.dateAdded,
 					missionPackId: mission.missionPackId
 				},
 				update: {
@@ -84,6 +88,7 @@ const { PrismaClient } = pkg;
 					factory: mission.factory,
 					variant: mission.variant,
 					verified: mission.verified,
+					dateAdded: mission.dateAdded,
 					missionPackId: mission.missionPackId
 				},
 				where: {

--- a/importer/import.js
+++ b/importer/import.js
@@ -5,7 +5,12 @@ const { PrismaClient } = pkg;
 (async function () {
 	const client = new PrismaClient();
 
-	const packs = JSON.parse(readFileSync('bombs.json').toString());
+	let packs = JSON.parse(readFileSync('bombs.json').toString());
+	for (let i = 0; i < packs.length; i++) {
+		if (packs[i].dateAdded != null) packs[i].dateAdded = new Date(packs[i].dateAdded);
+	}
+
+	packs.sort((a, b) => parseInt(a.id) - parseInt(b.id));
 	let missions = [];
 	let completions = [];
 	for (const pack of packs) {
@@ -13,12 +18,12 @@ const { PrismaClient } = pkg;
 			create: {
 				name: pack.name,
 				steamId: pack.steamID,
-				dateAdded: pack.dateAdded,
+				dateAdded: new Date(pack.dateAdded),
 				verified: pack.verified
 			},
 			update: {
 				steamId: pack.steamID,
-				dateAdded: pack.dateAdded,
+				dateAdded: new Date(pack.dateAdded),
 				verified: pack.verified
 			},
 			where: {
@@ -39,7 +44,7 @@ const { PrismaClient } = pkg;
 				timeMode: mission.timeMode,
 				variant: mission.variant,
 				verified: mission.verified,
-				dateAdded: mission.dateAdded,
+				dateAdded: mission.dateAdded == null ? null : new Date(mission.dateAdded),
 				missionPackId: missionPack.id
 			});
 			for (const completion of mission.completions) {
@@ -54,6 +59,7 @@ const { PrismaClient } = pkg;
 					notes: completion.notes,
 					missionId: mission.id,
 					missionName: mission.name,
+					dateAdded: completion.dateAdded == null ? null : new Date(completion.dateAdded),
 					verified: completion.verified
 				});
 			}
@@ -83,9 +89,12 @@ const { PrismaClient } = pkg;
 					missionPackId: mission.missionPackId
 				},
 				update: {
+					authors: mission.authors,
 					tpSolve: mission.tpSolve,
 					designedForTP: mission.designedForTP,
 					factory: mission.factory,
+					strikeMode: mission.strikeMode,
+					timeMode: mission.timeMode,
 					variant: mission.variant,
 					verified: mission.verified,
 					dateAdded: mission.dateAdded,
@@ -129,6 +138,7 @@ const { PrismaClient } = pkg;
 						mission: {
 							connect: { name: completion.missionName }
 						},
+						dateAdded: completion.dateAdded,
 						verified: completion.verified
 					}
 				})
@@ -147,6 +157,7 @@ const { PrismaClient } = pkg;
 						old: completion.old,
 						solo: completion.solo,
 						notes: completion.notes,
+						dateAdded: completion.dateAdded,
 						verified: completion.verified
 					}
 				})

--- a/importer/import.js
+++ b/importer/import.js
@@ -120,8 +120,9 @@ const { PrismaClient } = pkg;
 		});
 		let equalSolve = comp.findIndex(
 			c =>
+				c.solo == completion.solo &&
 				JSON.stringify(c.team.slice(0, 1).concat(c.team.slice(1).sort())) ==
-				JSON.stringify(completion.team.slice(0, 1).concat(completion.team.slice(1).sort()))
+					JSON.stringify(completion.team.slice(0, 1).concat(completion.team.slice(1).sort()))
 		);
 
 		if (equalSolve < 0) {

--- a/importer/newest.js
+++ b/importer/newest.js
@@ -22,6 +22,7 @@ const { PrismaClient } = pkg;
 				timeMode: mission.timeMode,
 				variant: mission.variant,
 				verified: mission.verified,
+				dateAdded: mission.dateAdded,
 				missionPack: pack.name
 			});
 			for (const completion of mission.completions) {

--- a/importer/newest.js
+++ b/importer/newest.js
@@ -5,7 +5,17 @@ const { PrismaClient } = pkg;
 (async function () {
 	const showOnlyVerified = false;
 	const howMany = 40;
-	const packs = JSON.parse(readFileSync('bombs.json').toString());
+	let packs = JSON.parse(readFileSync('bombs.json').toString());
+	for (let i = 0; i < packs.length; i++) {
+		if (packs[i].dateAdded != null) packs[i].dateAdded = new Date(packs[i].dateAdded);
+	}
+	function dateAddedSort(a, b) {
+		return a.dateAdded == null || b.dateAdded == null
+			? parseInt(b.id) - parseInt(a.id)
+			: b.dateAdded.getTime() - a.dateAdded.getTime();
+	}
+
+	packs.sort(dateAddedSort);
 	let missions = [];
 	let completions = [];
 	for (const pack of packs) {
@@ -22,7 +32,7 @@ const { PrismaClient } = pkg;
 				timeMode: mission.timeMode,
 				variant: mission.variant,
 				verified: mission.verified,
-				dateAdded: mission.dateAdded,
+				dateAdded: mission.dateAdded == null ? null : new Date(mission.dateAdded),
 				missionPack: pack.name
 			});
 			for (const completion of mission.completions) {
@@ -36,29 +46,29 @@ const { PrismaClient } = pkg;
 					solo: completion.solo,
 					notes: completion.notes,
 					missionName: mission.name,
+					dateAdded: completion.dateAdded == null ? null : new Date(completion.dateAdded),
 					verified: completion.verified
 				});
 			}
 		}
 	}
-	missions.sort((a, b) => parseInt(b.id) - parseInt(a.id));
-	completions.sort((a, b) => parseInt(b.id) - parseInt(a.id));
+	missions.sort(dateAddedSort);
+	completions.sort(dateAddedSort);
 
-	console.log('Packs');
+	console.log('----------Packs----------');
 	let count, i;
-	for (count = 0, i = 1; count < howMany; i++, count++) {
-		let pack = packs[packs.length - i];
+	for (count = 0, i = 0; count < howMany; i++, count++) {
 		if (!showOnlyVerified || pack.verified) {
-			pack.missions = pack.missions.map(m => m.name);
-			console.log(pack);
+			packs[i].missions = packs[i].missions.map(m => m.name);
+			console.log(packs[i]);
 		} else count -= 1;
 	}
-	console.log('\nMissions');
+	console.log('\n----------Missions----------');
 	for (count = 0, i = 0; count < howMany; i++, count++) {
 		if (!showOnlyVerified || !missions[i].verified) console.log(missions[i]);
 		else count -= 1;
 	}
-	console.log('\nCompletions');
+	console.log('\n----------Completions----------');
 	for (count = 0, i = 0; count < howMany; i++, count++) {
 		if (!showOnlyVerified || !completions[i].verified) console.log(completions[i]);
 		else count -= 1;

--- a/importer/newest.js
+++ b/importer/newest.js
@@ -1,0 +1,65 @@
+import { readFileSync } from 'fs';
+import pkg from '@prisma/client';
+const { PrismaClient } = pkg;
+
+(async function () {
+	const showOnlyVerified = false;
+	const howMany = 40;
+	const packs = JSON.parse(readFileSync('bombs.json').toString());
+	let missions = [];
+	let completions = [];
+	for (const pack of packs) {
+		for (const mission of pack.missions) {
+			missions.push({
+				id: mission.id,
+				name: mission.name,
+				authors: mission.authors,
+				bombs: mission.bombs,
+				tpSolve: mission.tpSolve,
+				designedForTP: mission.designedForTP,
+				factory: mission.factory,
+				strikeMode: mission.strikeMode,
+				timeMode: mission.timeMode,
+				variant: mission.variant,
+				verified: mission.verified,
+				missionPack: pack.name
+			});
+			for (const completion of mission.completions) {
+				completions.push({
+					id: completion.id,
+					proofs: completion.proofs,
+					time: completion.time,
+					team: completion.team,
+					first: completion.first,
+					old: completion.old,
+					solo: completion.solo,
+					notes: completion.notes,
+					missionName: mission.name,
+					verified: completion.verified
+				});
+			}
+		}
+	}
+	missions.sort((a, b) => parseInt(b.id) - parseInt(a.id));
+	completions.sort((a, b) => parseInt(b.id) - parseInt(a.id));
+
+	console.log('Packs');
+	let count, i;
+	for (count = 0, i = 1; count < howMany; i++, count++) {
+		let pack = packs[packs.length - i];
+		if (!showOnlyVerified || pack.verified) {
+			pack.missions = pack.missions.map(m => m.name);
+			console.log(pack);
+		} else count -= 1;
+	}
+	console.log('\nMissions');
+	for (count = 0, i = 0; count < howMany; i++, count++) {
+		if (!showOnlyVerified || !missions[i].verified) console.log(missions[i]);
+		else count -= 1;
+	}
+	console.log('\nCompletions');
+	for (count = 0, i = 0; count < howMany; i++, count++) {
+		if (!showOnlyVerified || !completions[i].verified) console.log(completions[i]);
+		else count -= 1;
+	}
+})();

--- a/prisma/migrations/20230209083325_add_original_logfile_link_to_missions/migration.sql
+++ b/prisma/migrations/20230209083325_add_original_logfile_link_to_missions/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Mission" ADD COLUMN     "logfile" TEXT;

--- a/prisma/migrations/20230211042432_date_added_to_missions_and_packs/migration.sql
+++ b/prisma/migrations/20230211042432_date_added_to_missions_and_packs/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Mission" ADD COLUMN     "dateAdded" INTEGER;
+
+-- AlterTable
+ALTER TABLE "MissionPack" ADD COLUMN     "dateAdded" INTEGER;

--- a/prisma/migrations/20230211042432_date_added_to_missions_and_packs/migration.sql
+++ b/prisma/migrations/20230211042432_date_added_to_missions_and_packs/migration.sql
@@ -1,5 +1,0 @@
--- AlterTable
-ALTER TABLE "Mission" ADD COLUMN     "dateAdded" INTEGER;
-
--- AlterTable
-ALTER TABLE "MissionPack" ADD COLUMN     "dateAdded" INTEGER;

--- a/prisma/migrations/20230226091947_add_date_added_to_uploadable_types/migration.sql
+++ b/prisma/migrations/20230226091947_add_date_added_to_uploadable_types/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Completion" ADD COLUMN     "dateAdded" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Mission" ADD COLUMN     "dateAdded" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "MissionPack" ADD COLUMN     "dateAdded" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,11 +18,12 @@ model User {
 }
 
 model MissionPack {
-  id       Int       @id @default(autoincrement())
-  name     String    @unique
-  steamId  String
-  missions Mission[]
-  verified Boolean   @default(true)
+  id        Int       @id @default(autoincrement())
+  name      String    @unique
+  steamId   String
+  missions  Mission[]
+  verified  Boolean   @default(true)
+  dateAdded Int?
 }
 
 model Mission {
@@ -39,6 +40,7 @@ model Mission {
   verified       Boolean      @default(true)
   variant        Int?
   logfile        String?
+  dateAdded      Int?
 
   missionPack   MissionPack? @relation(fields: [missionPackId], references: [id])
   missionPackId Int?
@@ -57,14 +59,14 @@ model Bomb {
 }
 
 model Completion {
-  id     Int      @id @default(autoincrement())
-  proofs String[]
-  time   Float
-  team   String[]
-  first  Boolean
-  old    Boolean
-  solo   Boolean
-  notes  String?
+  id        Int      @id @default(autoincrement())
+  proofs    String[]
+  time      Float
+  team      String[]
+  first     Boolean
+  old       Boolean
+  solo      Boolean
+  notes     String?
 
   mission   Mission @relation(fields: [missionId], references: [id], onDelete: Cascade)
   missionId Int

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model MissionPack {
   steamId   String
   missions  Mission[]
   verified  Boolean   @default(true)
-  dateAdded Int?
+  dateAdded DateTime?
 }
 
 model Mission {
@@ -40,7 +40,7 @@ model Mission {
   verified       Boolean      @default(true)
   variant        Int?
   logfile        String?
-  dateAdded      Int?
+  dateAdded      DateTime?
 
   missionPack   MissionPack? @relation(fields: [missionPackId], references: [id])
   missionPackId Int?
@@ -67,6 +67,7 @@ model Completion {
   old       Boolean
   solo      Boolean
   notes     String?
+  dateAdded DateTime?
 
   mission   Mission @relation(fields: [missionId], references: [id], onDelete: Cascade)
   missionId Int

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Mission {
   timeMode       String?
   verified       Boolean      @default(true)
   variant        Int?
+  logfile        String?
 
   missionPack   MissionPack? @relation(fields: [missionPackId], references: [id])
   missionPackId Int?

--- a/src/lib/cards/MissionCardInner.svelte
+++ b/src/lib/cards/MissionCardInner.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Bomb } from '$lib/types';
 	import type { Mission } from '$lib/types';
-	import { formatTime, getSolveTypes, listify, pluralize } from '$lib/util';
+	import { formatTime, pluralize } from '$lib/util';
 
 	export let mission: Mission;
 

--- a/src/lib/controls/Input.svelte
+++ b/src/lib/controls/Input.svelte
@@ -30,10 +30,14 @@
 	}
 
 	let error = '';
+	export const setValue = (val: any) => {
+		value = val;
+		displayValue = display(value);
+		doHandleInput(displayValue);
+	};
 
-	const handleInput = (e: Event & { currentTarget: EventTarget & HTMLInputElement }) => {
-		displayValue = e.currentTarget.value;
-		let newValue = parse(e.currentTarget.value);
+	function doHandleInput(val: any) {
+		let newValue = parse(val);
 		if (options !== null && !optionalOptions) {
 			let match = false;
 			for (const option of options) {
@@ -49,6 +53,10 @@
 
 		if (handleValidity(newValue)) value = newValue;
 		dispatch('input');
+	}
+	const handleInput = (e: Event & { currentTarget: EventTarget & HTMLInputElement }) => {
+		displayValue = e.currentTarget.value;
+		doHandleInput(displayValue);
 	};
 
 	function handleValidity(value: any, showErrors: boolean = true): boolean {

--- a/src/lib/controls/Input.svelte
+++ b/src/lib/controls/Input.svelte
@@ -122,6 +122,11 @@
 	input:disabled {
 		background-color: #888;
 	}
+
+	input[type="date"] {
+		background-color: lightgray;
+		color: black;
+	}
 	.hstack {
 		display: flex;
 		flex-direction: row;

--- a/src/lib/home/HomeFiltersMenu.svelte
+++ b/src/lib/home/HomeFiltersMenu.svelte
@@ -33,7 +33,15 @@
 		'Has Needy',
 		'Designed for TP'
 	];
-	let sortOptions = ['Alphabetical', 'Module Count', 'Bomb Time', 'Solves', 'Bomb Count', 'Rule Seeded Mods %'];
+	let sortOptions = [
+		'Alphabetical',
+		'Date Added',
+		'Module Count',
+		'Bomb Time',
+		'Solves',
+		'Bomb Count',
+		'Rule Seeded Mods %'
+	];
 	let limitDef: { [k: string]: number[] } = {
 		mods: [1, 600],
 		time: [1, 1800],

--- a/src/lib/home/HomeSearchBar.svelte
+++ b/src/lib/home/HomeSearchBar.svelte
@@ -177,16 +177,16 @@
 	function compare(
 		a: ID<Mission>,
 		b: ID<Mission>,
-		primary: (m: ID<Mission>) => number | null,
-		secondary: (m: ID<Mission>) => number | string | null
+		primary: (m: ID<Mission>) => number | undefined,
+		secondary: (m: ID<Mission>) => number | string | undefined
 	): boolean {
 		let prim = [primary(a), primary(b)];
-		let diff = prim[0] === null || prim[1] === null ? 0 : prim[0] - prim[1];
+		let diff = prim[0] === undefined || prim[1] === undefined ? 0 : prim[0] - prim[1];
 		if (diff > 0) return true;
 		else if (diff < 0) return false;
 		else {
 			let sec = [secondary(a), secondary(b)];
-			return sec[0] === null || sec[1] === null ? false : sec[0] > sec[1];
+			return sec[0] === undefined || sec[1] === undefined ? false : sec[0] > sec[1];
 		}
 	}
 
@@ -232,7 +232,7 @@
 						compare(
 							a,
 							b,
-							m => m.dateAdded,
+							m => m.dateAdded?.getTime(),
 							m => m.id
 						) != reverse
 							? 1

--- a/src/lib/home/HomeSearchBar.svelte
+++ b/src/lib/home/HomeSearchBar.svelte
@@ -310,7 +310,7 @@
 	});
 </script>
 
-<div class="search-bar">
+<div class="search-bar flex">
 	<div class="hstack controls">
 		<span>Results: {resultsText} of {missions.length}</span>
 		<LayoutSearchFilter
@@ -340,24 +340,28 @@
 			{/each}
 		</div>
 	</div>
-	<div id="controlTabs">
-		<div bind:this={filterTab} class="popup-tab filter-tab" on:click={() => popup(filters, filterTab, false)}>
+	<div class="flex control-tabs">
+		<div bind:this={filterTab} class="popup-tab filter-tab" on:click={() => popup(filters, filterTab, true, [-100, 0])}>
 			Filters
 		</div>
 	</div>
+	<HomeFiltersMenu
+		bind:div={filters}
+		on:click={() => preventDisappear(filters)}
+		on:update={homeOptionUpdate}
+		{modules} />
 </div>
-
-<HomeFiltersMenu bind:div={filters} on:click={() => preventDisappear(filters)} on:update={homeOptionUpdate} {modules} />
 
 <style>
 	.search-bar {
 		position: sticky;
 		background: var(--foreground);
 		top: calc(var(--stick-under-navbar) + 1px);
+	}
+	.search-bar > .hstack {
 		padding: 5px 0;
 	}
 	.search-bar > .hstack > span {
-		min-width: 100px;
 		margin-left: var(--gap);
 	}
 
@@ -376,20 +380,9 @@
 	.hstack.boxes {
 		gap: 7px;
 	}
-	#controlTabs {
-		position: absolute;
-		display: flex;
-		justify-content: right;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		user-select: none;
-		pointer-events: none;
-	}
-	#controlTabs * {
-		user-select: initial;
-		pointer-events: initial;
+	.control-tabs {
+		/* position: relative; */
+		top: 5px;
 	}
 
 	:global(#bomb-search-field) {

--- a/src/lib/home/HomeSearchBar.svelte
+++ b/src/lib/home/HomeSearchBar.svelte
@@ -340,7 +340,7 @@
 			{/each}
 		</div>
 	</div>
-	<div class="tabs">
+	<div id="controlTabs">
 		<div bind:this={filterTab} class="popup-tab filter-tab" on:click={() => popup(filters, filterTab, false)}>
 			Filters
 		</div>
@@ -376,7 +376,7 @@
 	.hstack.boxes {
 		gap: 7px;
 	}
-	.tabs {
+	#controlTabs {
 		position: absolute;
 		display: flex;
 		justify-content: right;
@@ -384,6 +384,12 @@
 		left: 0;
 		width: 100%;
 		height: 100%;
+		user-select: none;
+		pointer-events: none;
+	}
+	#controlTabs * {
+		user-select: initial;
+		pointer-events: initial;
 	}
 
 	:global(#bomb-search-field) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,7 @@ export type ID<T> = T & { id: number };
 export interface MissionPack {
 	name: string;
 	steamId: string;
+	dateAdded: number | null;
 }
 
 export type MissionPackSelection = Pick<ID<MissionPack>, 'id' | 'name'>;
@@ -39,6 +40,7 @@ export class Mission {
 	strikeMode: string | null = null;
 	timeMode: string | null = null;
 	logfile: string | null = null;
+	dateAdded: number | null = null;
 }
 
 export class Bomb {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,7 +22,7 @@ export type ID<T> = T & { id: number };
 export interface MissionPack {
 	name: string;
 	steamId: string;
-	dateAdded: number | null;
+	dateAdded: Date | null;
 }
 
 export type MissionPackSelection = Pick<ID<MissionPack>, 'id' | 'name'>;
@@ -40,7 +40,7 @@ export class Mission {
 	strikeMode: string | null = null;
 	timeMode: string | null = null;
 	logfile: string | null = null;
-	dateAdded: number | null = null;
+	dateAdded: Date | null = null;
 }
 
 export class Bomb {
@@ -69,6 +69,7 @@ export class Completion {
 	old = false;
 	solo = false;
 	notes: string | null = null;
+	dateAdded: Date | null = null;
 }
 
 export class IndividualCompletion {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ export class Mission {
 	factory: string | null = null;
 	strikeMode: string | null = null;
 	timeMode: string | null = null;
+	logfile: string | null = null;
 }
 
 export class Bomb {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -229,10 +229,9 @@ export function disappear(elem: HTMLElement) {
 export function preventDisappear(elem: HTMLElement) {
 	let classes = elem.classList;
 	let statString = Array.from(classes).find(c => c.startsWith('disappear-stat')) ?? '';
-	let stat = parseInt(statString?.substring(14) ?? '1');
 
 	classes.remove(statString);
-	classes.add(`disappear-stat${stat + 1}`);
+	classes.add('disappear-stat1');
 }
 
 export function popup(wnd: HTMLElement, obj: HTMLElement, relative = false, skew: number[] = [0, 0]) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,5 +1,5 @@
 import type * as client from '@prisma/client';
-import type { Bomb, FrontendUser, ID, Mission, Permission, Pool } from './types';
+import type { Bomb, FrontendUser, ID, Mission, Completion, MissionPack, Permission, Pool } from './types';
 import { redirect, error } from '@sveltejs/kit';
 import type { RepoModule } from './repo';
 import { TP_TEAM } from './const';
@@ -408,4 +408,9 @@ export function formatDate(dt: Date): string {
 	if (isNaN(dt?.getTime() ?? NaN)) return '';
 	const d = new Date(dt.getTime() - (dt.getTimezoneOffset() - 300) * 60000);
 	return d.toISOString().split('T')[0];
+}
+
+type DateSortable = ID<Mission> | ID<MissionPack> | ID<Completion>;
+export function dateAddedSort(a: DateSortable, b: DateSortable): number {
+	return a.dateAdded == null || b.dateAdded == null ? a.id - b.id : a.dateAdded.getTime() - b.dateAdded.getTime();
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -396,3 +396,14 @@ export function getLogfileLinks(link: string): string[] {
 	}
 	return [''];
 }
+
+export function parseDate(dt: string): Date | null {
+	const d = new Date(dt);
+	return isNaN(d.getTime()) ? null : new Date(+d + (d.getTimezoneOffset() + 300) * 60000);
+}
+
+export function formatDate(dt: Date): string {
+	if (isNaN(dt?.getTime() ?? NaN)) return '';
+	const d = new Date(dt.getTime() - (dt.getTimezoneOffset() - 300) * 60000);
+	return d.toISOString().split('T')[0];
+}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -410,7 +410,7 @@ export function formatDate(dt: Date): string {
 	return d.toISOString().split('T')[0];
 }
 
-type DateSortable = ID<Mission> | ID<MissionPack> | ID<Completion>;
+type DateSortable = { id: number; dateAdded: Date | null };
 export function dateAddedSort(a: DateSortable, b: DateSortable): number {
 	return a.dateAdded == null || b.dateAdded == null ? a.id - b.id : a.dateAdded.getTime() - b.dateAdded.getTime();
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -364,3 +364,35 @@ export function validateSteamID(str: string): string | boolean {
 	}
 	return true;
 }
+
+export function validateLogfileLink(link: string): string | boolean {
+	let url = getLogfileLinks(link);
+	if (url[0] === '') {
+		return 'Invalid Logfile Analyzer link';
+	}
+	return true;
+}
+
+export function getLogfileLinks(link: string): string[] {
+	let url: URL | null = null;
+	try {
+		url = new URL(link);
+	} catch (e: any) {
+		return [''];
+	}
+
+	let host = url.hostname.toLowerCase();
+	let path = url.pathname.toLowerCase();
+	if (
+		host.includes('ktane.timwi.de') &&
+		(path.includes('more/logfile') || path.includes('lfa')) &&
+		url.hash.includes('file=')
+	) {
+		let start = url.hash.indexOf('file=') + 5;
+		let end = url.hash.slice(start).search(/[^a-zA-Z0-9]/) + start;
+		if (end < start) end = url.hash.length;
+		let fileId = url.hash.slice(start, end);
+		return ['https://ktane.timwi.de/Logfiles/' + fileId + '.txt', 'https://ktane.timwi.de/lfa#file=' + fileId];
+	}
+	return [''];
+}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -2,6 +2,7 @@ import type * as client from '@prisma/client';
 import type { Bomb, FrontendUser, ID, Mission, Permission, Pool } from './types';
 import { redirect, error } from '@sveltejs/kit';
 import type { RepoModule } from './repo';
+import { TP_TEAM } from './const';
 
 export function formatTime(seconds: number, milliseconds = false): string {
 	let timeParts = [];
@@ -93,7 +94,9 @@ export function fixPools<T>(mission: T & { bombs: client.Bomb[] }): T & { bombs:
 export function getSolveTypes(mission: Mission) {
 	return {
 		normalSolve: mission.completions.some(completion => completion.team.length >= 2),
-		efmSolve: mission.completions.some(completion => completion.team.length == 1 && !completion.solo),
+		efmSolve: mission.completions.some(
+			completion => completion.team.length == 1 && !completion.solo && completion.team[0] !== TP_TEAM
+		),
 		soloSolve: mission.completions.some(completion => completion.solo)
 	};
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -43,13 +43,9 @@
 				<a class="block" href="/verify">Verify</a>
 			{/if}
 		{/if}
-		<div
-			style="margin-left: auto"
-			class="block info-tab"
-			bind:this={infoTab}
-			on:click={() => popup(infoMenu, infoTab, true, [8, 6])}>
-			Info
-			<HomeInfoMenu bind:div={infoMenu} on:click={() => preventDisappear(infoMenu)} />
+		<div style="margin-left: auto" class="block info-tab" bind:this={infoTab}>
+			<div on:click={() => popup(infoMenu, infoTab, true, [8, 6])}>Info</div>
+			<HomeInfoMenu bind:div={infoMenu} />
 		</div>
 
 		{#if user}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -237,13 +237,13 @@
 		cursor: pointer;
 		padding: 0.2em 0.5em 0.115em 28px;
 		position: relative;
-		top: 5px;
 		margin-left: 0.2em;
 		vertical-align: bottom;
 		background-size: 20px 20px;
 		background-position: 4px center;
 		background-repeat: no-repeat;
 		align-self: flex-end;
+		margin-right: var(--gap);
 	}
 
 	:global(.hidden) {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -8,6 +8,7 @@ export const load: PageServerLoad = async function () {
 			verified: true
 		},
 		select: {
+			id: true,
 			name: true,
 			authors: true,
 			bombs: true,
@@ -16,6 +17,7 @@ export const load: PageServerLoad = async function () {
 			factory: true,
 			timeMode: true,
 			strikeMode: true,
+			dateAdded: true,
 			completions: {
 				where: { verified: true }
 			}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import MissionCard from '$lib/cards/MissionCard.svelte';
 	import HomeSearchBar from '$lib/home/HomeSearchBar.svelte';
-	import type { Mission } from '$lib/types';
+	import type { ID, Mission } from '$lib/types';
 	import type { RepoModule } from '$lib/repo';
 
 	export let data;
-	let missions: Mission[] = data.missions;
+	let missions: ID<Mission>[] = data.missions;
 	let missionCards: any = {};
 	let modules: Record<string, RepoModule> = data.modules;
 

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -5,7 +5,7 @@
 	<h1 class="header">What’s New?</h1>
 </div>
 <div class="block update">
-	<h3>26 February 2023</h3>
+	<h3>1 March 2023</h3>
 	<ul>
 		<li>Missions and Mission Packs now have a Date Added field.</li>
 		<li>
@@ -17,7 +17,7 @@
 				</li>
 			</ul>
 		</li>
-		<li>When uploading a mission, a logfile link is now required instead of a file upload.</li>
+		<li>When uploading a mission, a Logfile Analyzer link is now required instead of a file upload.</li>
 		<li>Missions can now store a link to the logfile that defines its mission parameters.</li>
 		<li>New sort option on the home page: Date Added</li>
 		<li>A few minor bug fixes</li>

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -5,9 +5,9 @@
 	<h1 class="header">What’s New?</h1>
 </div>
 <div class="block update">
-	<h3>22 February 2023</h3>
+	<h3>26 February 2023</h3>
 	<ul>
-		<li>Missions and Mission Packs now have a Date Added field. These will be updated slowly over time.</li>
+		<li>Missions and Mission Packs now have a Date Added field.</li>
 		<li>
 			When pasting a logfile during a Solve upload, mission name and time are filled in from the logfile info.
 			<ul>
@@ -19,15 +19,7 @@
 		</li>
 		<li>When uploading a mission, a logfile link is now required instead of a file upload.</li>
 		<li>Missions can now store a link to the logfile that defines its mission parameters.</li>
-		<li>
-			New sort option on the home page: Date Added
-			<ul>
-				<li>
-					Until the older missions can be updated, only the newest missions (ones uploaded since the switchover in
-					September 2022) will be sorted correctly.
-				</li>
-			</ul>
-		</li>
+		<li>New sort option on the home page: Date Added</li>
 		<li>A few minor bug fixes</li>
 	</ul>
 </div>

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -5,6 +5,33 @@
 	<h1 class="header">What’s New?</h1>
 </div>
 <div class="block update">
+	<h3>22 February 2023</h3>
+	<ul>
+		<li>Missions and Mission Packs now have a Date Added field. These will be updated slowly over time.</li>
+		<li>
+			When pasting a logfile during a Solve upload, mission name and time are filled in from the logfile info.
+			<ul>
+				<li>
+					Make sure to double check what gets filled in; the info may be wrong in rare cases if the logfile contains
+					multiple missions or bombs.
+				</li>
+			</ul>
+		</li>
+		<li>When uploading a mission, a logfile link is now required instead of a file upload.</li>
+		<li>Missions can now store a link to the logfile that defines its mission parameters.</li>
+		<li>
+			New sort option on the home page: Date Added
+			<ul>
+				<li>
+					Until the older missions can be updated, only the newest missions (ones uploaded since the switchover in
+					September 2022) will be sorted correctly.
+				</li>
+			</ul>
+		</li>
+		<li>A few minor bug fixes</li>
+	</ul>
+</div>
+<div class="block update">
 	<h3>8 February 2023</h3>
 	<ul>
 		<li>New page: What's New? (You're looking at it!)</li>

--- a/src/routes/json/missiondata/+server.ts
+++ b/src/routes/json/missiondata/+server.ts
@@ -57,17 +57,24 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 		}
 	});
 
+	function minimize(obj: any) {
+		Object.keys(obj).forEach(k => {
+			if (obj[k] == null) delete obj[k];
+		});
+	}
+
 	let missionPacks: {
 		name: string;
 		steamID: string;
 		verified: boolean;
 		dateAdded: number | null;
-		missions: (Mission & { variant: null | number })[];
+		missions: any[]; //(Mission & { variant: null | number })[];
 	}[] = [];
 	missionsObj.forEach(miss => {
 		let bombs: Bomb[] = [];
 		Object.assign(bombs, miss.bombs);
 		let pack = missionPacks.find(mp => mp.steamID == miss.missionPack?.steamId);
+		for (let i = 0; i < miss.completions.length; i++) minimize(miss.completions[i]);
 		let newMission = {
 			name: miss.name,
 			id: miss.id,
@@ -84,16 +91,19 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			dateAdded: miss.dateAdded,
 			variant: miss.variant
 		};
+		minimize(newMission);
 		if (pack) {
 			pack.missions.push(newMission);
 		} else {
-			missionPacks.push({
+			let p = {
 				name: miss.missionPack?.name ?? '',
 				steamID: miss.missionPack?.steamId ?? '',
 				verified: miss.missionPack?.verified ?? false,
 				dateAdded: miss.missionPack?.dateAdded ?? null,
 				missions: [newMission]
-			});
+			};
+			minimize(p);
+			missionPacks.push(p);
 		}
 	});
 

--- a/src/routes/json/missiondata/+server.ts
+++ b/src/routes/json/missiondata/+server.ts
@@ -135,7 +135,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			missionPacks.push(pack);
 		}
 	});
-	missionPacks.sort((a: any, b: any) => dateAddedSort(a, b));
+	missionPacks.sort((a, b) => dateAddedSort(a, b));
 
 	return new Response(JSON.stringify(missionPacks));
 };

--- a/src/routes/json/missiondata/+server.ts
+++ b/src/routes/json/missiondata/+server.ts
@@ -1,7 +1,6 @@
 import client from '$lib/client';
-import { onlyUnique, getModule, hasPermission, forbidden } from '$lib/util';
 import { Bomb, Permission, type Mission } from '$lib/types';
-import type { MissionPack } from '@prisma/client';
+import { forbidden, hasPermission } from '$lib/util';
 import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
 
 export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
@@ -45,6 +44,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			timeMode: true,
 			variant: true,
 			verified: true,
+			logfile: true,
 			missionPack: {
 				select: {
 					verified: true,
@@ -77,6 +77,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			strikeMode: miss.strikeMode,
 			timeMode: miss.timeMode,
 			verified: miss.verified,
+			logfile: miss.logfile,
 			variant: miss.variant
 		};
 		if (pack) {

--- a/src/routes/json/missiondata/+server.ts
+++ b/src/routes/json/missiondata/+server.ts
@@ -45,10 +45,12 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			variant: true,
 			verified: true,
 			logfile: true,
+			dateAdded: true,
 			missionPack: {
 				select: {
 					verified: true,
 					name: true,
+					dateAdded: true,
 					steamId: true
 				}
 			}
@@ -59,6 +61,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 		name: string;
 		steamID: string;
 		verified: boolean;
+		dateAdded: number | null;
 		missions: (Mission & { variant: null | number })[];
 	}[] = [];
 	missionsObj.forEach(miss => {
@@ -78,6 +81,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			timeMode: miss.timeMode,
 			verified: miss.verified,
 			logfile: miss.logfile,
+			dateAdded: miss.dateAdded,
 			variant: miss.variant
 		};
 		if (pack) {
@@ -87,6 +91,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 				name: miss.missionPack?.name ?? '',
 				steamID: miss.missionPack?.steamId ?? '',
 				verified: miss.missionPack?.verified ?? false,
+				dateAdded: miss.missionPack?.dateAdded ?? null,
 				missions: [newMission]
 			});
 		}
@@ -98,6 +103,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			name: true,
 			steamId: true,
 			missions: true,
+			dateAdded: true,
 			verified: true
 		}
 	});
@@ -107,6 +113,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 				name: p.name,
 				steamID: p.steamId,
 				verified: p.verified,
+				dateAdded: p.dateAdded ?? null,
 				missions: []
 			});
 	});

--- a/src/routes/mission/[...mission]/+page.server.ts
+++ b/src/routes/mission/[...mission]/+page.server.ts
@@ -29,6 +29,7 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			strikeMode: true,
 			variant: true,
 			logfile: true,
+			dateAdded: true,
 			missionPack: {
 				select: {
 					name: true,

--- a/src/routes/mission/[...mission]/+page.server.ts
+++ b/src/routes/mission/[...mission]/+page.server.ts
@@ -28,6 +28,7 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			timeMode: true,
 			strikeMode: true,
 			variant: true,
+			logfile: true,
 			missionPack: {
 				select: {
 					name: true,

--- a/src/routes/mission/[...mission]/+page.svelte
+++ b/src/routes/mission/[...mission]/+page.svelte
@@ -29,9 +29,8 @@
 	const viewTitle =
 		'Pools view shows the actual module pools as defined by the mission author.\n' +
 		'Probabilities view shows probability that at least one instance of a module will be present on a bomb.';
-	let dateAdded = new Date(0);
-	dateAdded.setUTCSeconds(mission.dateAdded ?? 0);
 	const dateOptions: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+	// const dateOptions: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' };
 
 	function poolClass(mods: string[] = [], module: RepoModule | null = null): string {
 		let classes = '';
@@ -126,7 +125,7 @@
 		{/if}
 
 		{#if mission.dateAdded !== null}
-			<span class="date">{dateAdded.toLocaleDateString(undefined, dateOptions)}</span>
+			<span class="date">{mission.dateAdded.toLocaleDateString(undefined, dateOptions)}</span>
 		{/if}
 		{#if mission.logfile !== null}
 			<a class="logfile" href={mission.logfile}>Logfile</a>

--- a/src/routes/mission/[...mission]/+page.svelte
+++ b/src/routes/mission/[...mission]/+page.svelte
@@ -121,6 +121,10 @@
 		{:else}
 			---
 		{/if}
+
+		{#if hasPermission($page.data.user, Permission.VerifyMission) && mission.logfile !== null}
+			<a class="logfile" href={mission.logfile}>Original Logfile</a>
+		{/if}
 	</div>
 	{#if hasPermission($page.data.user, Permission.VerifyMission)}
 		<a href={$page.url.href + '/edit'} class="top-right">Edit</a>
@@ -268,8 +272,14 @@
 	.centered {
 		text-align: center;
 	}
-	a.pack {
+	a {
 		color: var(--text-color);
+	}
+	a.logfile {
+		margin-left: 20px;
+	}
+	a.variant {
+		margin-top: calc(var(--gap) * 3);
 	}
 
 	.pools {
@@ -354,10 +364,6 @@
 	.header {
 		font-weight: bold;
 		text-align: center;
-	}
-	a.variant {
-		color: var(--text-color);
-		margin-top: calc(var(--gap) * 3);
 	}
 
 	.top-right {

--- a/src/routes/mission/[...mission]/+page.svelte
+++ b/src/routes/mission/[...mission]/+page.svelte
@@ -29,6 +29,9 @@
 	const viewTitle =
 		'Pools view shows the actual module pools as defined by the mission author.\n' +
 		'Probabilities view shows probability that at least one instance of a module will be present on a bomb.';
+	let dateAdded = new Date(0);
+	dateAdded.setUTCSeconds(mission.dateAdded ?? 0);
+	const dateOptions: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
 
 	function poolClass(mods: string[] = [], module: RepoModule | null = null): string {
 		let classes = '';
@@ -122,8 +125,11 @@
 			---
 		{/if}
 
-		{#if hasPermission($page.data.user, Permission.VerifyMission) && mission.logfile !== null}
-			<a class="logfile" href={mission.logfile}>Original Logfile</a>
+		{#if mission.dateAdded !== null}
+			<span class="date">{dateAdded.toLocaleDateString(undefined, dateOptions)}</span>
+		{/if}
+		{#if mission.logfile !== null}
+			<a class="logfile" href={mission.logfile}>Logfile</a>
 		{/if}
 	</div>
 	{#if hasPermission($page.data.user, Permission.VerifyMission)}
@@ -275,7 +281,8 @@
 	a {
 		color: var(--text-color);
 	}
-	a.logfile {
+	a.logfile,
+	.date {
 		margin-left: 20px;
 	}
 	a.variant {

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -35,6 +35,7 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			timeMode: true,
 			strikeMode: true,
 			variant: true,
+			logfile: true,
 			missionPack: {
 				select: {
 					name: true,
@@ -228,6 +229,7 @@ export const actions: Actions = {
 				name: mission.name,
 				tpSolve: mission.tpSolve,
 				designedForTP: mission.designedForTP,
+				logfile: mission.logfile,
 				variant: mission.variant
 			}
 		});

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -36,6 +36,7 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			strikeMode: true,
 			variant: true,
 			logfile: true,
+			dateAdded: true,
 			missionPack: {
 				select: {
 					name: true,
@@ -230,6 +231,7 @@ export const actions: Actions = {
 				tpSolve: mission.tpSolve,
 				designedForTP: mission.designedForTP,
 				logfile: mission.logfile,
+				dateAdded: mission.dateAdded,
 				variant: mission.variant
 			}
 		});

--- a/src/routes/mission/[mission]/edit/+page.svelte
+++ b/src/routes/mission/[mission]/edit/+page.svelte
@@ -8,9 +8,11 @@
 	import { Permission, type Completion, type ID, type Bomb, Pool, type MissionPackSelection } from '$lib/types';
 	import {
 		displayStringList,
+		formatDate,
 		formatTime,
 		getLogfileLinks,
 		hasPermission,
+		parseDate,
 		parseInteger,
 		parseList,
 		parseTime,
@@ -48,11 +50,17 @@
 
 	let modified = false;
 	let tpCompletion = false;
+	let date: Date | null = null;
+	if (mission.dateAdded !== null) {
+		date = new Date(0);
+		date.setUTCSeconds(mission.dateAdded);
+	}
 	$: {
 		let log = getLogfileLinks(logfile);
 		mission.logfile = log[0] === '' ? null : log[1];
 		tpCompletion = mission.completions.some(c => c.team[0] === TP_TEAM);
 		if (tpCompletion) mission.tpSolve = true;
+		mission.dateAdded = date === null ? null : Math.round(date.getTime() / 1000);
 		modified = !equal(mission, originalMission);
 	}
 
@@ -177,6 +185,14 @@
 		bind:value={mission.strikeMode}
 		options={[null, 'Local', 'Global']}
 		display={mode => mode ?? 'None'} />
+	<Input
+		type="date"
+		id="mission-date"
+		label="Date Added"
+		classes="light"
+		parse={parseDate}
+		display={formatDate}
+		bind:value={date} />
 	<Checkbox label="Designed for TP" id="designed-for-tp" bind:checked={mission.designedForTP} />
 </div>
 <div class="block">
@@ -187,7 +203,7 @@
 		forceValidate
 		bind:value={logfile} />
 	{#if mission.logfile !== null}
-		<a href={mission.logfile}>Original Logfile</a>
+		<a href={mission.logfile}>Logfile</a>
 	{/if}
 </div>
 {#if !mission.verified}

--- a/src/routes/mission/[mission]/edit/+page.svelte
+++ b/src/routes/mission/[mission]/edit/+page.svelte
@@ -40,6 +40,7 @@
 
 	function setOriginalMission() {
 		originalMission = JSON.parse(JSON.stringify(mission));
+		originalMission.dateAdded = mission.dateAdded;
 	}
 
 	for (const bomb of mission.bombs) {
@@ -50,17 +51,11 @@
 
 	let modified = false;
 	let tpCompletion = false;
-	let date: Date | null = null;
-	if (mission.dateAdded !== null) {
-		date = new Date(0);
-		date.setUTCSeconds(mission.dateAdded);
-	}
 	$: {
 		let log = getLogfileLinks(logfile);
 		mission.logfile = log[0] === '' ? null : log[1];
 		tpCompletion = mission.completions.some(c => c.team[0] === TP_TEAM);
 		if (tpCompletion) mission.tpSolve = true;
-		mission.dateAdded = date === null ? null : Math.round(date.getTime() / 1000);
 		modified = !equal(mission, originalMission);
 	}
 
@@ -192,7 +187,7 @@
 		classes="light"
 		parse={parseDate}
 		display={formatDate}
-		bind:value={date} />
+		bind:value={mission.dateAdded} />
 	<Checkbox label="Designed for TP" id="designed-for-tp" bind:checked={mission.designedForTP} />
 </div>
 <div class="block">

--- a/src/routes/missionpack/[...missionpack]/+page.server.ts
+++ b/src/routes/missionpack/[...missionpack]/+page.server.ts
@@ -33,6 +33,7 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			},
 			steamId: true,
 			name: true,
+			dateAdded: true,
 			verified: true
 		}
 	});

--- a/src/routes/missionpack/[...missionpack]/+page.svelte
+++ b/src/routes/missionpack/[...missionpack]/+page.svelte
@@ -8,9 +8,8 @@
 	export let data;
 	export let pack: EditMissionPack = data.pack;
 
-	let dateAdded = new Date(0);
-	dateAdded.setUTCSeconds(pack.dateAdded ?? 0);
 	const dateOptions: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+	// const dateOptions: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' };
 </script>
 
 <svelte:head>
@@ -21,7 +20,7 @@
 	<div class="flex">
 		<span>{pluralize(pack.missions.length, 'Mission')}</span>
 		{#if pack.dateAdded !== null}
-			<span class="date">{dateAdded.toLocaleDateString(undefined, dateOptions)}</span>
+			<span class="date">{pack.dateAdded.toLocaleDateString(undefined, dateOptions)}</span>
 		{/if}
 		<a class="steam" href="https://steamcommunity.com/sharedfiles/filedetails/?id={pack.steamId}">Steam Workshop</a>
 	</div>

--- a/src/routes/missionpack/[...missionpack]/+page.svelte
+++ b/src/routes/missionpack/[...missionpack]/+page.svelte
@@ -7,6 +7,10 @@
 
 	export let data;
 	export let pack: EditMissionPack = data.pack;
+
+	let dateAdded = new Date(0);
+	dateAdded.setUTCSeconds(pack.dateAdded ?? 0);
+	const dateOptions: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
 </script>
 
 <svelte:head>
@@ -16,6 +20,9 @@
 	<h1 class="header">{pack.name}</h1>
 	<div class="flex">
 		<span>{pluralize(pack.missions.length, 'Mission')}</span>
+		{#if pack.dateAdded !== null}
+			<span class="date">{dateAdded.toLocaleDateString(undefined, dateOptions)}</span>
+		{/if}
 		<a class="steam" href="https://steamcommunity.com/sharedfiles/filedetails/?id={pack.steamId}">Steam Workshop</a>
 	</div>
 	{#if hasPermission($page.data.user, Permission.VerifyMissionPack)}

--- a/src/routes/missionpack/[missionpack]/edit/+page.server.ts
+++ b/src/routes/missionpack/[missionpack]/edit/+page.server.ts
@@ -37,6 +37,7 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			steamId: true,
 			name: true,
 			verified: true,
+			dateAdded: true,
 			id: true
 		}
 	});
@@ -79,6 +80,7 @@ export const actions: Actions = {
 			},
 			data: {
 				steamId: pack.steamId,
+				dateAdded: pack.dateAdded,
 				name: pack.name
 			}
 		});

--- a/src/routes/missionpack/[missionpack]/edit/+page.svelte
+++ b/src/routes/missionpack/[missionpack]/edit/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Input from '$lib/controls/Input.svelte';
 
-	import { getSteamID, validateSteamID } from '$lib/util';
+	import { formatDate, getSteamID, parseDate, validateSteamID } from '$lib/util';
 	import equal from 'fast-deep-equal';
 	import { applyAction } from '$app/forms';
 	import type { EditMissionPack } from '../../_types';
@@ -19,7 +19,16 @@
 
 	setOriginalMission();
 
-	$: modified = !equal(pack, originalPack);
+	let modified = false;
+	let date: Date | null = null;
+	if (pack.dateAdded !== null) {
+		date = new Date(0);
+		date.setUTCSeconds(pack.dateAdded);
+	}
+	$: {
+		pack.dateAdded = date === null ? null : Math.round(date.getTime() / 1000);
+		modified = !equal(pack, originalPack);
+	}
 
 	async function saveChanges() {
 		const fData = new FormData();
@@ -66,6 +75,16 @@
 		instantFormat={false}
 		forceValidate
 		bind:value={pack.steamId} />
+	<div class="flex">
+		<Input
+			type="date"
+			id="pack-date"
+			label="Date Added"
+			classes="light"
+			parse={parseDate}
+			display={formatDate}
+			bind:value={date} />
+	</div>
 	<div class="actions">
 		<button on:click={deleteMissionPack}>Delete</button>
 	</div>

--- a/src/routes/missionpack/[missionpack]/edit/+page.svelte
+++ b/src/routes/missionpack/[missionpack]/edit/+page.svelte
@@ -15,20 +15,12 @@
 
 	function setOriginalMission() {
 		originalPack = JSON.parse(JSON.stringify(pack));
+		originalPack.dateAdded = pack.dateAdded;
 	}
 
 	setOriginalMission();
 
-	let modified = false;
-	let date: Date | null = null;
-	if (pack.dateAdded !== null) {
-		date = new Date(0);
-		date.setUTCSeconds(pack.dateAdded);
-	}
-	$: {
-		pack.dateAdded = date === null ? null : Math.round(date.getTime() / 1000);
-		modified = !equal(pack, originalPack);
-	}
+	$: modified = !equal(pack, originalPack);
 
 	async function saveChanges() {
 		const fData = new FormData();
@@ -83,7 +75,7 @@
 			classes="light"
 			parse={parseDate}
 			display={formatDate}
-			bind:value={date} />
+			bind:value={pack.dateAdded} />
 	</div>
 	<div class="actions">
 		<button on:click={deleteMissionPack}>Delete</button>

--- a/src/routes/upload/+page.server.ts
+++ b/src/routes/upload/+page.server.ts
@@ -7,7 +7,8 @@ export const load: PageServerLoad = async function () {
 		select: {
 			name: true,
 			completions: true,
-			authors: true
+			authors: true,
+			factory: true
 		},
 		where: {
 			verified: true
@@ -22,6 +23,10 @@ export const load: PageServerLoad = async function () {
 	});
 
 	return {
+		factoryStatus: missions.reduce((result: any, current) => {
+			result[current.name] = current.factory;
+			return result;
+		}, {}),
 		missionNames: missions.map(mission => mission.name).sort(excludeArticleSort),
 		authorNames: missions
 			.map(mission => mission.authors)

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -5,6 +5,7 @@
 	import type { MissionPackSelection } from '$lib/types';
 	export let data;
 
+	let factoryStatus: { [name: string]: string | null } = data.factoryStatus;
 	let missionNames: string[] = data.missionNames;
 	let authorNames: string[] = data.authorNames;
 	let solverNames: string[] = data.solverNames;
@@ -30,7 +31,7 @@
 {:else if section == 'missionpack'}
 	<MissionPackSection />
 {:else}
-	<CompletionSection {missionNames} {solverNames} />
+	<CompletionSection {missionNames} {solverNames} {factoryStatus} />
 {/if}
 
 <style>

--- a/src/routes/upload/_CompletionSection.svelte
+++ b/src/routes/upload/_CompletionSection.svelte
@@ -14,6 +14,7 @@
 	let missionName: string = '';
 
 	let completion: Completion = new Completion();
+	completion.dateAdded = new Date();
 
 	let valid: boolean = false;
 
@@ -108,7 +109,7 @@
 	}
 
 	function validateTime(time: number): string | boolean {
-		if (time == null) return 'Ivalid time';
+		if (time == null) return 'Invalid time';
 		else if (time > 0) return true;
 		else return 'Time must be ≥ 0.01s';
 	}

--- a/src/routes/upload/_CompletionSection.svelte
+++ b/src/routes/upload/_CompletionSection.svelte
@@ -9,6 +9,7 @@
 
 	export let missionNames: string[];
 	export let solverNames: string[];
+	export let factoryStatus: { [name: string]: string | null };
 
 	let missionName: string = '';
 
@@ -72,6 +73,7 @@
 			return lines[lineIndex++];
 		}
 
+		let time = 0;
 		while (lineIndex < lines.length) {
 			let line = readLine().trim();
 			if (line.startsWith('[Tweaks] LFAEvent ')) {
@@ -86,14 +88,18 @@
 				const event = JSON.parse(json);
 				if (event.type === 'ROUND_START' && event.mission) {
 					let match = missionNames.find(name => name.toLowerCase() === event.mission.toLowerCase());
-					if (match !== undefined) missionName = match;
+					if (match !== undefined) {
+						missionName = match;
+						time = 0;
+					}
 				} else if (event.type === 'BOMB_SOLVE' && event.bombTime) {
 					let n = parseFloat(event.bombTime);
 					if (!isNaN(n)) {
 						n = Math.max(Math.round(n * 100) / 100, MIN_TIME);
+						if (factoryStatus[missionName] === 'Sequence') time += n;
+						else time = n;
 						parsedTimes.push(n);
-						// completion.time = n;
-						timeInput.setValue(n);
+						timeInput.setValue(time);
 					}
 				}
 			}

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Input from '$lib/controls/Input.svelte';
 	import type { MissionPack } from '$lib/types';
-	import { getSteamID, isOnlyDigits, validateSteamID } from '$lib/util';
+	import { getSteamID, validateSteamID } from '$lib/util';
 	import toast from 'svelte-french-toast';
 
 	let pack: MissionPack = {

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -7,7 +7,7 @@
 	let pack: MissionPack = {
 		name: '',
 		steamId: '',
-		dateAdded: Math.round(Date.now() / 1000)
+		dateAdded: new Date()
 	};
 
 	let invalid = false;

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -6,7 +6,8 @@
 
 	let pack: MissionPack = {
 		name: '',
-		steamId: ''
+		steamId: '',
+		dateAdded: Math.round(Date.now() / 1000)
 	};
 
 	let invalid = false;

--- a/src/routes/upload/_MissionSection.svelte
+++ b/src/routes/upload/_MissionSection.svelte
@@ -56,7 +56,7 @@
 					strikeMode: null,
 					missionPack: null,
 					replace: false,
-					dateAdded: Math.round(Date.now() / 1000),
+					dateAdded: new Date(),
 					logfile: parsedLogfileLink
 				};
 

--- a/src/routes/upload/_MissionSection.svelte
+++ b/src/routes/upload/_MissionSection.svelte
@@ -56,6 +56,7 @@
 					strikeMode: null,
 					missionPack: null,
 					replace: false,
+					dateAdded: Math.round(Date.now() / 1000),
 					logfile: parsedLogfileLink
 				};
 

--- a/src/routes/upload/completion/+server.ts
+++ b/src/routes/upload/completion/+server.ts
@@ -28,8 +28,9 @@ export async function POST({ request }: RequestEvent) {
 
 	let equalSolves = mission.completions.filter(
 		c =>
+			c.solo == completion.solo &&
 			JSON.stringify(c.team.slice(0, 1).concat(c.team.slice(1).sort())) ==
-			JSON.stringify(completion.team.slice(0, 1).concat(completion.team.slice(1).sort()))
+				JSON.stringify(completion.team.slice(0, 1).concat(completion.team.slice(1).sort()))
 	);
 	if (equalSolves.some(s => s.verified == false))
 		//don't allow duplicate solve uploads that are already in the verify queue

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -26,6 +26,7 @@ export async function POST({ request }: RequestEvent) {
 				strikeMode: mission.strikeMode,
 				designedForTP: mission.designedForTP,
 				missionPackId: mission.missionPack?.id,
+				logfile: mission.logfile,
 				verified: false
 			}
 		});

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -27,6 +27,7 @@ export async function POST({ request }: RequestEvent) {
 				designedForTP: mission.designedForTP,
 				missionPackId: mission.missionPack?.id,
 				logfile: mission.logfile,
+				dateAdded: mission.dateAdded,
 				verified: false
 			}
 		});

--- a/src/routes/user/[user]/+page.svelte
+++ b/src/routes/user/[user]/+page.svelte
@@ -167,12 +167,14 @@
 	}
 
 	let wrView = writable(byRole);
+	let render = false;
 	if (browser) {
 		byRole = JSON.parse(localStorage.getItem('user-solves-view') || JSON.stringify(viewOptions[0]));
 		wrView.subscribe(value => {
 			localStorage.setItem('user-solves-view', JSON.stringify(value));
 		});
 		storeView();
+		render = true;
 	}
 	function storeView() {
 		wrView.set(byRole);
@@ -207,7 +209,7 @@
 	<Select id="view-select" label="View:" sideLabel options={viewOptions} bind:value={byRole} on:change={storeView} />
 </div>
 <div class="block"><h2>Solves</h2></div>
-{#if byRole == viewOptions[1]}
+{#if render && byRole == viewOptions[1]}
 	{#each Object.entries(missionsNames) as [key, compList]}
 		{#if compList.length > 0}
 			{@const dist = selectDistinctSolveCount(key, stats)}
@@ -239,7 +241,7 @@
 			</div>
 		{/if}
 	{/each}
-{:else}
+{:else if render}
 	<div class="solves flex grow">
 		{#each Object.values(missions).sort((a, b) => a.name.localeCompare(b.name)) as mission}
 			<MissionCompletionCard {mission} {username} />

--- a/src/routes/verify/+page.server.ts
+++ b/src/routes/verify/+page.server.ts
@@ -30,6 +30,7 @@ export const load = async function ({ parent, locals }: any) {
 				factory: true,
 				timeMode: true,
 				strikeMode: true,
+				logfile: true,
 				missionPack: {
 					select: {
 						id: true,

--- a/src/routes/verify/+page.server.ts
+++ b/src/routes/verify/+page.server.ts
@@ -22,19 +22,19 @@ export const load = async function ({ parent, locals }: any) {
 				name: true,
 				authors: true,
 				bombs: {
-					orderBy: {
-						id: 'asc'
-					}
+					orderBy: { id: 'asc' }
 				},
 				designedForTP: true,
 				factory: true,
 				timeMode: true,
 				strikeMode: true,
 				logfile: true,
+				dateAdded: true,
 				missionPack: {
 					select: {
 						id: true,
-						name: true
+						name: true,
+						dateAdded: true
 					}
 				}
 			}
@@ -52,7 +52,11 @@ export const load = async function ({ parent, locals }: any) {
 						}
 					} as MissionQueueItem;
 				})
-				.sort((a, b) => a.mission.id - b.mission.id)
+				.sort((a, b) =>
+					a.mission.dateAdded === null || b.mission.dateAdded === null
+						? a.mission.id - b.mission.id
+						: a.mission.dateAdded - b.mission.dateAdded
+				)
 		);
 	}
 
@@ -122,7 +126,11 @@ export const load = async function ({ parent, locals }: any) {
 						pack
 					} as MissionPackQueueItem;
 				})
-				.sort((a, b) => a.pack.id - b.pack.id)
+				.sort((a, b) =>
+					a.pack.dateAdded === null || b.pack.dateAdded === null
+						? a.pack.id - b.pack.id
+						: a.pack.dateAdded - b.pack.dateAdded
+				)
 		);
 	}
 

--- a/src/routes/verify/+page.server.ts
+++ b/src/routes/verify/+page.server.ts
@@ -1,7 +1,7 @@
 import client from '$lib/client';
 import type { CompletionQueueItem, MissionQueueItem, QueueItem } from '$lib/types';
 import { Permission, type MissionPackQueueItem } from '$lib/types';
-import { fixPools, forbidden, hasAnyPermission, hasPermission, onlyUnique } from '$lib/util';
+import { dateAddedSort, fixPools, forbidden, hasAnyPermission, hasPermission, onlyUnique } from '$lib/util';
 
 export const load = async function ({ parent, locals }: any) {
 	const { user } = await parent();
@@ -52,11 +52,7 @@ export const load = async function ({ parent, locals }: any) {
 						}
 					} as MissionQueueItem;
 				})
-				.sort((a, b) =>
-					a.mission.dateAdded === null || b.mission.dateAdded === null
-						? a.mission.id - b.mission.id
-						: a.mission.dateAdded - b.mission.dateAdded
-				)
+				.sort((a, b) => dateAddedSort(a.mission, b.mission))
 		);
 	}
 
@@ -106,7 +102,7 @@ export const load = async function ({ parent, locals }: any) {
 						mission: fixPools(completion.mission)
 					} as CompletionQueueItem;
 				})
-				.sort((a, b) => a.completion.id - b.completion.id)
+				.sort((a, b) => dateAddedSort(a.completion, b.completion))
 		);
 	}
 
@@ -126,11 +122,7 @@ export const load = async function ({ parent, locals }: any) {
 						pack
 					} as MissionPackQueueItem;
 				})
-				.sort((a, b) =>
-					a.pack.dateAdded === null || b.pack.dateAdded === null
-						? a.pack.id - b.pack.id
-						: a.pack.dateAdded - b.pack.dateAdded
-				)
+				.sort((a, b) => dateAddedSort(a.pack, b.pack))
 		);
 	}
 

--- a/src/routes/verify/+page.svelte
+++ b/src/routes/verify/+page.svelte
@@ -15,8 +15,9 @@
 	function matchingSolve(item: CompletionQueueItem) {
 		return item.mission.completions.findIndex(
 			c =>
+				c.solo == item.completion.solo &&
 				JSON.stringify(c.team.slice(0, 1).concat(c.team.slice(1).sort())) ==
-				JSON.stringify(item.completion.team.slice(0, 1).concat(item.completion.team.slice(1).sort()))
+					JSON.stringify(item.completion.team.slice(0, 1).concat(item.completion.team.slice(1).sort()))
 		);
 	}
 

--- a/src/routes/verify/item/+server.ts
+++ b/src/routes/verify/item/+server.ts
@@ -53,6 +53,7 @@ export const POST: RequestHandler = async function ({ locals, request }: Request
 								strikeMode: item.mission.strikeMode,
 								missionPackId: item.mission.missionPack?.id,
 								name: name,
+								logfile: item.mission.logfile,
 								designedForTP: item.mission.designedForTP
 							}
 						});


### PR DESCRIPTION
1) Uploading a new mission with a logfile is now done with a link instead of a file upload, the link used to create the mission page is saved in the database and displayed on a mission page (editable from the edit page). #37  https://discord.com/channels/887088776818602055/1004869408734335056/1073582857877999776
2) Fixed the page flash on a /user/<name> page when you click on your own name or refresh the page (flash only happened if "By Role" was your preference)
3) Pasting a logfile in the Proof box, when uploading a new solve, grabs the mission name and time remaining on the bomb down to hundredths of a second. https://discord.com/channels/887088776818602055/1004869408734335056/1073798669658226748
4) Date Added fields for missions and mission packs (editable from the edit pages) https://discord.com/channels/887088776818602055/1004869408734335056/1073906060080984125
    - New mission and mission pack uploads record the Data Added automatically.
5) Sorting missions by Date Added #94
6) Mission [[UPDATE]] pages (see below, these pages are created when uploading a logfile to replace a mission's parameters) now show the solves of the mission they are updating.
![image](https://user-images.githubusercontent.com/10985005/221423420-7cd875f3-7ad6-43b7-9e44-19088e6f7fc5.png)

7) The new kind of TP solves (with proof link and time) don't count as EFMs on the Mission card, https://discord.com/channels/887088776818602055/887088777409986572/1078417668324999198

The new logfile field and both dateAdded field will be populated using some node.js scripts shortly after merging this.