### PR TITLE
Top solves, unverified uploads, missionIDs, ranks

### DIFF
--- a/importer/import.js
+++ b/importer/import.js
@@ -50,6 +50,7 @@ const { PrismaClient } = pkg;
 				dateAdded: mission.dateAdded == null ? null : new Date(mission.dateAdded),
 				uploadedBy: mission.uploadedBy,
 				inGameId: mission.inGameId,
+				inGameName: mission.inGameName,
 				notes: mission.notes,
 				missionPackId: missionPack.id
 			});
@@ -96,6 +97,7 @@ const { PrismaClient } = pkg;
 					dateAdded: mission.dateAdded,
 					uploadedBy: mission.uploadedBy,
 					inGameId: mission.inGameId,
+					inGameName: mission.inGameName,
 					notes: mission.notes,
 					missionPackId: mission.missionPackId
 				},
@@ -112,6 +114,7 @@ const { PrismaClient } = pkg;
 					dateAdded: mission.dateAdded,
 					uploadedBy: mission.uploadedBy,
 					inGameId: mission.inGameId,
+					inGameName: mission.inGameName,
 					notes: mission.notes,
 					missionPackId: mission.missionPackId
 				},

--- a/importer/import.js
+++ b/importer/import.js
@@ -49,6 +49,7 @@ const { PrismaClient } = pkg;
 				logfile: mission.logfile,
 				dateAdded: mission.dateAdded == null ? null : new Date(mission.dateAdded),
 				uploadedBy: mission.uploadedBy,
+				inGameId: mission.inGameId,
 				notes: mission.notes,
 				missionPackId: missionPack.id
 			});
@@ -94,6 +95,7 @@ const { PrismaClient } = pkg;
 					logfile: mission.logfile,
 					dateAdded: mission.dateAdded,
 					uploadedBy: mission.uploadedBy,
+					inGameId: mission.inGameId,
 					notes: mission.notes,
 					missionPackId: mission.missionPackId
 				},
@@ -109,6 +111,7 @@ const { PrismaClient } = pkg;
 					logfile: mission.logfile,
 					dateAdded: mission.dateAdded,
 					uploadedBy: mission.uploadedBy,
+					inGameId: mission.inGameId,
 					notes: mission.notes,
 					missionPackId: mission.missionPackId
 				},

--- a/prisma/migrations/20230923051845_add_mission_in_game_id/migration.sql
+++ b/prisma/migrations/20230923051845_add_mission_in_game_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Mission" ADD COLUMN     "inGameId" TEXT;

--- a/prisma/migrations/20231002185220_add_in_game_mission_name_to_missions/migration.sql
+++ b/prisma/migrations/20231002185220_add_in_game_mission_name_to_missions/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Mission" ADD COLUMN     "inGameName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Mission {
   dateAdded      DateTime?
   notes          String?
   uploadedBy     String?
+  inGameId       String?
 
   missionPack   MissionPack? @relation(fields: [missionPackId], references: [id])
   missionPackId Int?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model Mission {
   notes          String?
   uploadedBy     String?
   inGameId       String?
+  inGameName     String?
 
   missionPack   MissionPack? @relation(fields: [missionPackId], references: [id])
   missionPackId Int?

--- a/src/lib/cards/MissionCard.svelte
+++ b/src/lib/cards/MissionCard.svelte
@@ -10,6 +10,7 @@
 	export let id: string = '';
 	export let cardID: string = '';
 	export let card: any = null;
+	export let nolink: boolean = false;
 
 	const solveTypes = getSolveTypes(mission);
 
@@ -26,7 +27,7 @@
 {#if selectable}
 	<div class="selectable-card" bind:this={card} id={cardID}>
 		<input {id} type="checkbox" bind:checked={selected} />
-		<label for={id} class="mission selectable" class:selected>
+		<label for={id} class="mission selectable" class:selected class:nolink>
 			<MissionCardInner {mission} />
 		</label>
 	</div>
@@ -98,7 +99,7 @@
 		outline: var(--accent) 2px solid;
 	}
 
-	label {
+	label:not(.nolink) {
 		cursor: pointer;
 	}
 </style>

--- a/src/lib/cards/MissionCardInner.svelte
+++ b/src/lib/cards/MissionCardInner.svelte
@@ -14,7 +14,7 @@
 <div class="mission-name">{mission.name}</div>
 <div class="stats">
 	{#if bombs.length > 1}
-		{bombs.length} B ·
+		{bombs.length} Bombs ·
 	{/if}
 	{pluralize(statBomb.modules, bombs.length > 1 ? 'Mod' : 'Module')} ·
 	{#if mission.timeMode === 'Global'}
@@ -23,16 +23,23 @@
 		{formatTime(bombs.map(bomb => bomb.time).reduce((a, b) => a + b, 0))} ·
 	{/if}
 	{#if mission.strikeMode === 'Global'}
-		{pluralize(Math.max(...bombs.map(bomb => bomb.strikes)), 'Strike')} ·
+		<span>{pluralize(Math.max(...bombs.map(bomb => bomb.strikes)), 'Strike')}</span> ·
 	{:else}
-		{pluralize(
-			bombs.map(bomb => bomb.strikes).reduce((a, b) => a + b, 0),
-			'Strike'
-		)} ·
+		<span
+			>{pluralize(
+				bombs.map(bomb => bomb.strikes).reduce((a, b) => a + b, 0),
+				'Strike'
+			)}</span> ·
 	{/if}
-	{pluralize(statBomb.widgets, 'Widget')}
+	<span>{pluralize(statBomb.widgets, 'Widget')}</span>
 	{#if mission.factory !== null}
 		· {mission.factory}
+		{#if mission.timeMode == 'Global'}
+			+ GTime
+		{/if}
+		{#if mission.strikeMode == 'Global'}
+			+ GStrk
+		{/if}
 	{/if}
 </div>
 
@@ -41,5 +48,8 @@
 		font-style: italic;
 		font-size: 85%;
 		color: var(--light-text-color);
+	}
+	.stats > span {
+		white-space: nowrap;
 	}
 </style>

--- a/src/lib/cards/SingleCompletionCard.svelte
+++ b/src/lib/cards/SingleCompletionCard.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { TP_TEAM } from '$lib/const';
+	import type { MissionCompletion } from '$lib/types';
+	import { formatTime, getPersonColor, listify } from '$lib/util';
+
+	export let comp: MissionCompletion;
+	export let username: string;
+	export let showTime: boolean = false;
+
+	let tp = username === TP_TEAM;
+	const dateOptions: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+</script>
+
+<a href="/mission/{encodeURIComponent(comp.mission.name)}">
+	<div
+		class="block flex full"
+		style:background-color={getPersonColor(comp.team.length, comp.team.indexOf(username), comp.solo, tp)}>
+		{#if comp.time !== undefined && showTime}
+			<span class="time" class:first={comp.first} class:old={comp.old} title={formatTime(comp.time, true)}
+				>{formatTime(comp.time)}</span>
+		{/if}
+		<span class="mission-name">{comp.mission.name}</span>
+		{#if comp.dateAdded}
+			<span>{comp.dateAdded.toLocaleDateString(undefined, dateOptions)}</span>
+		{/if}
+	</div>
+</a>
+
+<style>
+	.full {
+		justify-content: space-between;
+		gap: 20px;
+	}
+	.time {
+		padding: 0 3px;
+	}
+	.time.first {
+		border-radius: 5px;
+		color: black;
+		background-color: hsl(43, 74%, 70%);
+	}
+	.time.old {
+		font-style: italic;
+	}
+	a {
+		text-decoration: none;
+		color: black;
+	}
+	.mission-name {
+		text-decoration: underline;
+	}
+</style>

--- a/src/lib/home/HomeSearchBar.svelte
+++ b/src/lib/home/HomeSearchBar.svelte
@@ -126,8 +126,6 @@
 		let percent =
 			(modulesInMission[msName].filter(m => (options.modules['EnabledList'] || []).includes(m.ModuleID)).length * 100) /
 			modulesInMission[msName].length;
-		// if (percent >= options.profPerc[0])
-		// 	console.log(msName + ": " + percent);
 		return percent;
 	}
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,7 @@ export class Mission {
 	dateAdded: Date | null = null;
 	notes: string | null = null;
 	uploadedBy: string | null = null;
+	inGameId: string | null = null;
 }
 
 export class Bomb {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -142,5 +142,8 @@ export class MissionCompletion {
 	team: string[] = [];
 	solo = false;
 	dateAdded: Date | null = null;
+	first = false;
+	time: number | undefined = undefined;
+	old: boolean | undefined = undefined;
 	mission: Pick<Mission, 'name'> = { name: '' };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,7 @@ export class Mission {
 	notes: string | null = null;
 	uploadedBy: string | null = null;
 	inGameId: string | null = null;
+	inGameName: string | null = null;
 }
 
 export class Bomb {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -378,6 +378,13 @@ export function validateLogfileLink(link: string): string | boolean {
 	return true;
 }
 
+export function validateMissionID(id: string): string | boolean {
+	if (id !== null && !id.match(/mod_(.+?)_(.+)/)) {
+		return 'format expected: mod_missionPackId_missionId';
+	}
+	return true;
+}
+
 export function getLogfileLinks(link: string): string[] {
 	let url: URL | null = null;
 	try {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -81,6 +81,7 @@
 		--textbox-background: rgb(15, 15, 15);
 		--popup-background: #fafaff;
 		--contrast-block-background: rgb(220, 220, 220);
+		--accent-gray: #BBB;
 		--light-text-color: rgb(100, 100, 100);
 		--link-text-color: currentColor;
 		--link-visited-text-color: currentColor;
@@ -99,6 +100,7 @@
 			--textbox-background: lightgray;
 			--popup-background: rgb(50, 50, 50);
 			--contrast-block-background: rgb(50, 50, 50);
+			--accent-gray: #444;
 			--light-text-color: rgb(150, 150, 150);
 			--link-text-color: rgb(200, 200, 200);
 			--link-visited-text-color: rgb(130, 130, 130);

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -5,6 +5,30 @@
 	<h1 class="header">What’s New?</h1>
 </div>
 <div class="block update">
+	<h3>10 October 2023</h3>
+	<ul>
+		<li>Users can see their own unverified uploads on their user page (must be logged in).</li>
+		<li>User pages now feature Top Times and First Solves statistics.</li>
+		<li>
+			Ranks on the <a href="/solvers">Solvers</a> page are now equal for any users with equal Distinct and Total solve counts.
+		</li>
+		<li>
+			Mission ID is now required when uploading a mission.
+			<ul>
+				<li>
+					This is the string (of format "mod_missionPackId_missionId") that uniquely identifies the mission in Unity.
+				</li>
+				<li>
+					When uploading a mission, the logfile importer will attempt to find the mission ID in the logfile, but do
+					double-check the value it fills in because the format of logfiles is inconsistent on this matter.
+				</li>
+				<li>The mission ID is now present in the <a href="/json/missionsreduced">missions endpoint</a>.</li>
+			</ul>
+		</li>
+		<li>A few bug fixes on solve uploads.</li>
+	</ul>
+</div>
+<div class="block update">
 	<h3>26 September 2023</h3>
 	<ul>
 		<li>

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -5,7 +5,7 @@
 	<h1 class="header">What’s New?</h1>
 </div>
 <div class="block update">
-	<h3>10 October 2023</h3>
+	<h3>22 October 2023</h3>
 	<ul>
 		<li>Users can see their own unverified uploads on their user page (must be logged in).</li>
 		<li>User pages now feature Top Times and First Solves statistics.</li>
@@ -24,6 +24,10 @@
 				</li>
 				<li>The mission ID is now present in the <a href="/json/missionsreduced">missions endpoint</a>.</li>
 			</ul>
+		</li>
+		<li>
+			The in-game name of a mission (which may differ from what it's called on this site) is now in the
+			<a href="/json/missionsreduced">missions endpoint</a>.
 		</li>
 		<li>A few bug fixes on solve uploads.</li>
 	</ul>

--- a/src/routes/json/_util.ts
+++ b/src/routes/json/_util.ts
@@ -1,0 +1,5 @@
+export function minimize(obj: any) {
+	Object.keys(obj).forEach(k => {
+		if (obj[k] == null) delete obj[k];
+	});
+}

--- a/src/routes/json/missiondata/+server.ts
+++ b/src/routes/json/missiondata/+server.ts
@@ -11,14 +11,13 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 		orderBy: { id: 'asc' },
 		select: {
 			name: true,
-			id: true,
 			authors: true,
 			bombs: {
 				orderBy: { id: 'asc' },
 				select: {
 					modules: true,
-					time: true,
 					strikes: true,
+					time: true,
 					widgets: true,
 					pools: true
 				}
@@ -26,39 +25,40 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			completions: {
 				orderBy: { id: 'asc' },
 				select: {
-					verified: true,
-					id: true,
-					proofs: true,
-					time: true,
-					team: true,
+					dateAdded: true,
 					first: true,
+					id: true,
 					notes: true,
 					old: true,
-					dateAdded: true,
+					proofs: true,
+					solo: true,
+					team: true,
+					time: true,
 					uploadedBy: true,
-					solo: true
+					verified: true
 				}
 			},
+			dateAdded: true,
 			designedForTP: true,
-			tpSolve: true,
 			factory: true,
+			id: true,
+			inGameId: true,
+			logfile: true,
+			notes: true,
 			strikeMode: true,
 			timeMode: true,
+			tpSolve: true,
+			uploadedBy: true,
 			variant: true,
 			verified: true,
-			logfile: true,
-			dateAdded: true,
-			uploadedBy: true,
-			inGameId: true,
-			notes: true,
 			missionPack: {
 				select: {
-					id: true,
-					verified: true,
 					name: true,
 					dateAdded: true,
+					id: true,
+					steamId: true,
 					uploadedBy: true,
-					steamId: true
+					verified: true
 				}
 			}
 		}
@@ -71,12 +71,12 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 	}
 
 	let missionPacks: {
-		id: number;
 		name: string;
+		dateAdded: Date | null;
+		id: number;
+		missions: any[];
 		steamID: string;
 		verified: boolean;
-		dateAdded: Date | null;
-		missions: any[]; //(Mission & { variant: null | number })[];
 	}[] = [];
 	missionsObj.forEach(miss => {
 		let bombs: Bomb[] = [];
@@ -85,35 +85,35 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 		for (let i = 0; i < miss.completions.length; i++) minimize(miss.completions[i]);
 		let newMission = {
 			name: miss.name,
-			id: miss.id,
 			authors: miss.authors,
 			bombs: bombs,
 			completions: miss.completions,
-			tpSolve: miss.tpSolve,
+			dateAdded: miss.dateAdded,
 			designedForTP: miss.designedForTP,
 			factory: miss.factory,
+			id: miss.id,
+			inGameId: miss.inGameId,
+			logfile: miss.logfile,
+			notes: miss.notes,
 			strikeMode: miss.strikeMode,
 			timeMode: miss.timeMode,
-			verified: miss.verified,
-			logfile: miss.logfile,
-			dateAdded: miss.dateAdded,
+			tpSolve: miss.tpSolve,
 			uploadedBy: miss.uploadedBy,
-			inGameId: miss.inGameId,
-			notes: miss.notes,
-			variant: miss.variant
+			variant: miss.variant,
+			verified: miss.verified
 		};
 		minimize(newMission);
 		if (pack) {
 			pack.missions.push(newMission);
 		} else {
 			let p = {
-				id: miss.missionPack?.id ?? 0,
 				name: miss.missionPack?.name ?? '',
-				steamID: miss.missionPack?.steamId ?? '',
-				verified: miss.missionPack?.verified ?? false,
 				dateAdded: miss.missionPack?.dateAdded ?? null,
+				id: miss.missionPack?.id ?? 0,
+				missions: [newMission],
+				steamID: miss.missionPack?.steamId ?? '',
 				uploadedBy: miss.missionPack?.uploadedBy ?? null,
-				missions: [newMission]
+				verified: miss.missionPack?.verified ?? false
 			};
 			minimize(p);
 			missionPacks.push(p);
@@ -123,11 +123,11 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 	const packs = await client.missionPack.findMany({
 		orderBy: { id: 'asc' },
 		select: {
-			id: true,
 			name: true,
-			steamId: true,
-			missions: true,
 			dateAdded: true,
+			id: true,
+			missions: true,
+			steamId: true,
 			uploadedBy: true,
 			verified: true
 		}
@@ -135,13 +135,13 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 	packs.forEach(p => {
 		if (missionPacks.findIndex(mp => mp.name == p.name) < 0) {
 			let pack = {
-				id: p.id,
 				name: p.name,
-				steamID: p.steamId,
-				verified: p.verified,
 				dateAdded: p.dateAdded ?? null,
+				id: p.id,
+				missions: [],
+				steamID: p.steamId,
 				uploadedby: p.uploadedBy,
-				missions: []
+				verified: p.verified
 			};
 			minimize(pack);
 			missionPacks.push(pack);

--- a/src/routes/json/missiondata/+server.ts
+++ b/src/routes/json/missiondata/+server.ts
@@ -2,6 +2,7 @@ import client from '$lib/client';
 import { Bomb, Permission } from '$lib/types';
 import { dateAddedSort, forbidden, hasPermission } from '$lib/util';
 import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
+import { minimize } from '../_util';
 
 export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 	if (!hasPermission(locals.user, Permission.DownloadDatabase)) {
@@ -43,6 +44,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			factory: true,
 			id: true,
 			inGameId: true,
+			inGameName: true,
 			logfile: true,
 			notes: true,
 			strikeMode: true,
@@ -63,12 +65,6 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			}
 		}
 	});
-
-	function minimize(obj: any) {
-		Object.keys(obj).forEach(k => {
-			if (obj[k] == null) delete obj[k];
-		});
-	}
 
 	let missionPacks: {
 		name: string;
@@ -93,6 +89,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			factory: miss.factory,
 			id: miss.id,
 			inGameId: miss.inGameId,
+			inGameName: miss.inGameName,
 			logfile: miss.logfile,
 			notes: miss.notes,
 			strikeMode: miss.strikeMode,

--- a/src/routes/json/missiondata/+server.ts
+++ b/src/routes/json/missiondata/+server.ts
@@ -49,6 +49,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			logfile: true,
 			dateAdded: true,
 			uploadedBy: true,
+			inGameId: true,
 			notes: true,
 			missionPack: {
 				select: {
@@ -97,6 +98,7 @@ export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
 			logfile: miss.logfile,
 			dateAdded: miss.dateAdded,
 			uploadedBy: miss.uploadedBy,
+			inGameId: miss.inGameId,
 			notes: miss.notes,
 			variant: miss.variant
 		};

--- a/src/routes/json/missions/+server.ts
+++ b/src/routes/json/missions/+server.ts
@@ -1,5 +1,6 @@
 import client from '$lib/client';
 import { withoutArticle } from '$lib/util';
+import { minimize } from '../_util';
 
 export async function GET() {
 	const missions = await client.mission.findMany({
@@ -11,6 +12,7 @@ export async function GET() {
 			authors: true,
 			bombs: true,
 			inGameId: true,
+			inGameName: true,
 			tpSolve: true,
 			designedForTP: true,
 			completions: {
@@ -23,15 +25,18 @@ export async function GET() {
 	let result = JSON.stringify(
 		missions
 			.map(m => {
-				return {
+				let mission = {
 					name: m.name,
 					authors: m.authors,
 					bombs: m.bombs,
 					missionId: m.inGameId,
+					inGameName: m.inGameName,
 					designedForTP: m.designedForTP,
 					tpSolve: m.tpSolve,
 					completions: m.completions.length
 				};
+				minimize(mission);
+				return mission;
 			})
 			.sort((a, b) => {
 				return withoutArticle(a.name).localeCompare(withoutArticle(b.name));

--- a/src/routes/json/missions/+server.ts
+++ b/src/routes/json/missions/+server.ts
@@ -10,7 +10,9 @@ export async function GET() {
 			name: true,
 			authors: true,
 			bombs: true,
+			inGameId: true,
 			tpSolve: true,
+			designedForTP: true,
 			completions: {
 				where: {
 					verified: true
@@ -25,6 +27,8 @@ export async function GET() {
 					name: m.name,
 					authors: m.authors,
 					bombs: m.bombs,
+					missionId: m.inGameId,
+					designedForTP: m.designedForTP,
 					tpSolve: m.tpSolve,
 					completions: m.completions.length
 				};

--- a/src/routes/json/missionsreduced/+server.ts
+++ b/src/routes/json/missionsreduced/+server.ts
@@ -1,6 +1,7 @@
 import client from '$lib/client';
 import { onlyUnique, withoutArticle } from '$lib/util';
 import type { Mission } from '$lib/types';
+import { minimize } from '../_util';
 
 export async function GET() {
 	const missionsObj = await client.mission.findMany({
@@ -12,6 +13,7 @@ export async function GET() {
 			authors: true,
 			bombs: true,
 			inGameId: true,
+			inGameName: true,
 			designedForTP: true,
 			tpSolve: true,
 			completions: {
@@ -40,16 +42,19 @@ export async function GET() {
 						time: b.time
 					};
 				});
-				return {
+				let mission = {
 					name: m.name,
 					authors: m.authors,
 					bombs: reducedBombs,
 					missionId: m.inGameId,
+					inGameName: m.inGameName,
 					designedForTP: m.designedForTP,
 					moduleList: list,
 					tpSolve: m.tpSolve,
 					completions: m.completions.length
 				};
+				minimize(mission);
+				return mission;
 			})
 			.sort((a, b) => {
 				return withoutArticle(a.name).localeCompare(withoutArticle(b.name));

--- a/src/routes/json/missionsreduced/+server.ts
+++ b/src/routes/json/missionsreduced/+server.ts
@@ -11,6 +11,7 @@ export async function GET() {
 			name: true,
 			authors: true,
 			bombs: true,
+			inGameId: true,
 			designedForTP: true,
 			tpSolve: true,
 			completions: {
@@ -43,6 +44,7 @@ export async function GET() {
 					name: m.name,
 					authors: m.authors,
 					bombs: reducedBombs,
+					missionId: m.inGameId,
 					designedForTP: m.designedForTP,
 					moduleList: list,
 					tpSolve: m.tpSolve,

--- a/src/routes/mission/[...mission]/+page.server.ts
+++ b/src/routes/mission/[...mission]/+page.server.ts
@@ -44,6 +44,7 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			logfile: true,
 			dateAdded: true,
 			uploadedBy: true,
+			inGameId: true,
 			notes: true,
 			missionPack: {
 				select: {
@@ -96,7 +97,8 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 	return {
 		mission: {
 			...missionResult,
-			uploadedBy: verify ? uploadedBy : null
+			uploadedBy: verify ? uploadedBy : null,
+			inGameId: verify ? missionResult.inGameId : null
 		},
 		variants,
 		modules: await getData()

--- a/src/routes/mission/[...mission]/+page.svelte
+++ b/src/routes/mission/[...mission]/+page.svelte
@@ -115,6 +115,14 @@
 </svelte:head>
 <div class="block relative">
 	<h1 class="header">{mission.name}</h1>
+	<div class="infobar flex gray">
+		{#if mission.inGameId}
+			<span>{mission.inGameId}</span>
+		{/if}
+		{#if mission.uploadedBy}
+			<span>Uploaded by: <a href="/user/{encodeURIComponent(mission.uploadedBy)}">{mission.uploadedBy}</a></span>
+		{/if}
+	</div>
 	<div class="infobar flex">
 		<span>
 			by {mission.authors.join(', ')} from
@@ -131,9 +139,6 @@
 		{/if}
 		{#if mission.logfile !== null}
 			<a class="logfile" href={mission.logfile}>Logfile</a>
-		{/if}
-		{#if mission.uploadedBy}
-			<span>Uploaded by: <a href="/user/{encodeURIComponent(mission.uploadedBy)}">{mission.uploadedBy}</a></span>
 		{/if}
 	</div>
 	{#if hasPermission($page.data.user, Permission.VerifyMission)}
@@ -288,6 +293,10 @@
 	.infobar {
 		justify-content: center;
 		gap: 25px;
+	}
+	.infobar.gray {
+		opacity: 60%;
+		line-height: 1.5;
 	}
 	.date {
 		white-space: nowrap;

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -38,6 +38,7 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			logfile: true,
 			dateAdded: true,
 			notes: true,
+			inGameId: true,
 			missionPack: {
 				select: {
 					name: true,
@@ -80,7 +81,8 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 	return {
 		mission: {
 			...missionResult,
-			variantOf: firstVariant?.name ?? ''
+			variantOf: firstVariant?.name ?? '',
+			uploadedBy: null
 		},
 		missionNames: missions.map(m => m.name).sort(excludeArticleSort),
 		packs,
@@ -234,6 +236,7 @@ export const actions: Actions = {
 				logfile: mission.logfile,
 				dateAdded: mission.dateAdded,
 				notes: mission.notes,
+				inGameId: mission.inGameId,
 				variant: mission.variant
 			}
 		});

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -39,6 +39,7 @@ export const load: PageServerLoad = async function ({ params, locals }: ServerLo
 			dateAdded: true,
 			notes: true,
 			inGameId: true,
+			inGameName: true,
 			missionPack: {
 				select: {
 					name: true,
@@ -237,6 +238,7 @@ export const actions: Actions = {
 				dateAdded: mission.dateAdded,
 				notes: mission.notes,
 				inGameId: mission.inGameId,
+				inGameName: mission.inGameName,
 				variant: mission.variant
 			}
 		});

--- a/src/routes/mission/[mission]/edit/+page.svelte
+++ b/src/routes/mission/[mission]/edit/+page.svelte
@@ -140,24 +140,34 @@
 <svelte:head>
 	<title>{mission.name}</title>
 </svelte:head>
-<div class="block flex grow relative">
-	<Input label="Name" id="mission-name" bind:value={mission.name} />
-	<Input label="Authors" id="mission-authors" bind:value={mission.authors} parse={parseList} />
-	<Input
-		label="Mission Pack"
-		id="mission-pack"
-		bind:value={mission.missionPack}
-		required
-		instantFormat={false}
-		options={packs}
-		display={pack => pack?.name}
-		validate={value => value !== null} />
-	<Input
-		id="mission-variant"
-		label="Variant of"
-		options={missionNames}
-		validate={value => value !== null}
-		bind:value={mission.variantOf} />
+<div class="block relative">
+	<div class="flex top-edit-controls">
+		<Input label="Name" id="mission-name" bind:value={mission.name} />
+		<Input label="Authors" id="mission-authors" bind:value={mission.authors} parse={parseList} />
+		<Input
+			label="Mission Pack"
+			id="mission-pack"
+			bind:value={mission.missionPack}
+			required
+			instantFormat={false}
+			options={packs}
+			display={pack => pack?.name}
+			validate={value => value !== null} />
+		<Input
+			id="mission-variant"
+			label="Variant of"
+			options={missionNames}
+			validate={value => value !== null}
+			bind:value={mission.variantOf} />
+	</div>
+	<div class="flex top-edit-controls">
+		<Input
+			id="mission-ingamename"
+			label="In-Game Name"
+			parse={val => (val?.trim().length > 0 ? val.trim() : null)}
+			display={val => val ?? ''}
+			bind:value={mission.inGameName} />
+	</div>
 	<div class="actions">
 		<button on:click={deleteMission}>Delete</button>
 	</div>
@@ -363,6 +373,9 @@
 </div>
 
 <style>
+	:global(.top-edit-controls > div) {
+		width: 24.5%;
+	}
 	.main-content {
 		display: grid;
 		grid-template-columns: 2fr 1fr;

--- a/src/routes/mission/[mission]/edit/+page.svelte
+++ b/src/routes/mission/[mission]/edit/+page.svelte
@@ -16,7 +16,8 @@
 		parseInteger,
 		parseList,
 		parseTime,
-		validateLogfileLink
+		validateLogfileLink,
+		validateMissionID
 	} from '$lib/util';
 	import equal from 'fast-deep-equal';
 	import { sortBombs } from '../../_shared';
@@ -180,6 +181,16 @@
 		bind:value={mission.strikeMode}
 		options={[null, 'Local', 'Global']}
 		display={mode => mode ?? 'None'} />
+	<Input
+		classes="mission-id-edit"
+		name="Mission ID"
+		label="Mission ID"
+		id="mission-ingameid"
+		validate={validateMissionID}
+		parse={val => (val?.length > 0 ? val : null)}
+		display={val => val ?? ''}
+		bind:value={mission.inGameId}
+		forceValidate />
 	<Input
 		type="date"
 		id="mission-date"
@@ -477,5 +488,8 @@
 		box-shadow: var(--foreground) 0 0 10px;
 		color: #ddd;
 		background-color: rgb(15, 15, 15);
+	}
+	:global(input.mission-id-edit) {
+		width: 300px;
 	}
 </style>

--- a/src/routes/mission/[mission]/edit/+page.svelte
+++ b/src/routes/mission/[mission]/edit/+page.svelte
@@ -57,7 +57,7 @@
 		mission.logfile = log[0] === '' ? null : log[1];
 		tpCompletion = mission.completions.some(c => c.team[0] === TP_TEAM);
 		if (tpCompletion) mission.tpSolve = true;
-		modified = !equal(mission, originalMission);
+		modified = JSON.stringify(originalMission) !== JSON.stringify(mission);
 	}
 
 	function intnan0(val: number): boolean | string {

--- a/src/routes/solvers/+page.server.ts
+++ b/src/routes/solvers/+page.server.ts
@@ -70,8 +70,10 @@ export const load: PageServerLoad = async function () {
 	const sortedCompleters = Object.values(completers);
 	sortedCompleters.sort((a, b) => {
 		const distinct = b.distinct - a.distinct;
+		const totalDiff = total(b) - total(a);
 		if (distinct !== 0) return distinct;
-		return total(b) - total(a);
+		if (totalDiff !== 0) return totalDiff;
+		return a.name.localeCompare(b.name);
 	});
 
 	return {

--- a/src/routes/solvers/+page.svelte
+++ b/src/routes/solvers/+page.svelte
@@ -3,6 +3,18 @@
 	import type { Completer } from '$lib/types';
 	export let data;
 	let completers: Completer[] = data.completers;
+	let ranks: { [name: string]: number } = {};
+	let rank = 1;
+	for (let c = 0; c < completers.length; c++) {
+		const comp = completers[c];
+		const prev = c > 0 ? completers[c - 1] : completers[0];
+		if (
+			c > 0 &&
+			(prev.distinct != comp.distinct || prev.defuser + prev.expert + prev.efm != comp.defuser + comp.expert + comp.efm)
+		)
+			rank++;
+		ranks[comp.name] = rank;
+	}
 </script>
 
 <svelte:head>
@@ -20,8 +32,8 @@
 	<b class="block">Defuser</b>
 	<b class="block">Expert</b>
 	<b class="block">EFM</b>
-	{#each completers as completer, index}
-		<div class="block">{index + 1}</div>
+	{#each completers as completer}
+		<div class="block">{ranks[completer.name]}</div>
 		<div class="block"><a href="/user/{encodeURIComponent(completer.name)}">{completer.name}</a></div>
 		<div class="block">{completer.distinct}</div>
 		<div class="block">{completer.defuser + completer.expert + completer.efm}</div>
@@ -52,6 +64,11 @@
 	.table b.block {
 		position: sticky;
 		top: var(--stick-under-navbar);
+	}
+	.table .block {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 	}
 
 	a {

--- a/src/routes/upload/+page.server.ts
+++ b/src/routes/upload/+page.server.ts
@@ -27,7 +27,6 @@ export const load = async function ({ parent }: any) {
 	});
 
 	return {
-		user,
 		factoryStatus: missions.reduce((result: any, current) => {
 			result[current.name] = current.factory;
 			return result;

--- a/src/routes/upload/+page.server.ts
+++ b/src/routes/upload/+page.server.ts
@@ -14,6 +14,7 @@ export const load = async function ({ parent }: any) {
 			authors: true,
 			factory: true,
 			timeMode: true,
+			inGameName: true,
 			bombs: {
 				select: { time: true }
 			}
@@ -34,10 +35,9 @@ export const load = async function ({ parent }: any) {
 	return {
 		missionInfo: missions.reduce((info: { [name: string]: any }, miss: any) => {
 			info[miss.name] = {};
+			info[miss.name]['ingame'] = miss.inGameName;
 			info[miss.name]['factory'] = miss.factory;
-			info['timeMode'] = {};
 			info[miss.name]['timeMode'] = miss.timeMode;
-			info['time'] = {};
 			info[miss.name]['time'] =
 				miss.timeMode === 'Global'
 					? Math.max(miss.bombs.map((bomb: any) => bomb.time))

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -5,8 +5,7 @@
 	import type { FrontendUser, MissionPackSelection } from '$lib/types';
 	export let data;
 
-	let factoryStatus: { [name: string]: string | null } = data.factoryStatus;
-	let missionNames: string[] = data.missionNames;
+	let missionInfo: { [name: string]: number } = data.missionInfo;
 	let authorNames: string[] = data.authorNames;
 	let solverNames: string[] = data.solverNames;
 	let packs: MissionPackSelection[] = data.packs;
@@ -27,11 +26,11 @@
 	</div>
 </div>
 {#if section == 'mission'}
-	<MissionSection {missionNames} {authorNames} {packs} />
+	<MissionSection missionNames={Object.keys(missionInfo)} {authorNames} {packs} />
 {:else if section == 'missionpack'}
 	<MissionPackSection />
 {:else}
-	<CompletionSection {missionNames} {solverNames} {factoryStatus} />
+	<CompletionSection {missionInfo} {solverNames} />
 {/if}
 
 <style>

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -26,7 +26,7 @@
 	</div>
 </div>
 {#if section == 'mission'}
-	<MissionSection missionNames={Object.keys(missionInfo)} {authorNames} {packs} />
+	<MissionSection {missionInfo} {authorNames} {packs} />
 {:else if section == 'missionpack'}
 	<MissionPackSection />
 {:else}

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -10,7 +10,6 @@
 	let authorNames: string[] = data.authorNames;
 	let solverNames: string[] = data.solverNames;
 	let packs: MissionPackSelection[] = data.packs;
-	let user: FrontendUser = data.user;
 
 	let section: 'solve' | 'mission' | 'missionpack' = 'solve';
 </script>
@@ -28,11 +27,11 @@
 	</div>
 </div>
 {#if section == 'mission'}
-	<MissionSection {missionNames} {authorNames} {packs} {user} />
+	<MissionSection {missionNames} {authorNames} {packs} />
 {:else if section == 'missionpack'}
-	<MissionPackSection {user} />
+	<MissionPackSection />
 {:else}
-	<CompletionSection {missionNames} {solverNames} {factoryStatus} {user} />
+	<CompletionSection {missionNames} {solverNames} {factoryStatus} />
 {/if}
 
 <style>

--- a/src/routes/upload/_CompletionSection.svelte
+++ b/src/routes/upload/_CompletionSection.svelte
@@ -2,7 +2,7 @@
 	import Checkbox from '$lib/controls/Checkbox.svelte';
 	import CompletionCard from '$lib/cards/CompletionCard.svelte';
 	import Input from '$lib/controls/Input.svelte';
-	import { Completion, type FrontendUser } from '$lib/types';
+	import { Completion } from '$lib/types';
 	import { formatTime, getLogfileLinks, parseTime } from '$lib/util';
 	import toast from 'svelte-french-toast';
 	import { TP_TEAM } from '$lib/const';
@@ -88,7 +88,11 @@
 
 				const event = JSON.parse(json);
 				if (event.type === 'ROUND_START' && event.mission) {
-					let match = missionNames.find(name => name.toLowerCase() === event.mission.toLowerCase());
+					let match = missionNames.find(
+						name =>
+							event.mission.toLowerCase() ===
+							(missionInfo[name]['ingame'] != null ? missionInfo[name]['ingame'] : name).toLowerCase()
+					);
 					if (match !== undefined) {
 						missionName = match;
 						time = 0;
@@ -97,7 +101,11 @@
 					let n = parseFloat(event.bombTime);
 					if (!isNaN(n)) {
 						n = Math.max(Math.round(n * 100) / 100, MIN_TIME);
-						if (missionInfo[missionName]['factory'] === 'Sequence' && missionInfo[missionName]['timeMode'] !== 'Global')
+						if (
+							missionInfo[missionName] != undefined &&
+							missionInfo[missionName]['factory'] === 'Sequence' &&
+							missionInfo[missionName]['timeMode'] !== 'Global'
+						)
 							time = Math.min(time + n, missionInfo[missionName]['time']);
 						else time = n;
 						parsedTimes.push(n);
@@ -109,7 +117,8 @@
 	}
 
 	function validateTime(time: number): string | boolean {
-		let maxTime = missionName.length > 0 ? missionInfo[missionName]['time'] ?? Infinity : Infinity;
+		let maxTime =
+			missionName.length > 0 || missionInfo[missionName] == undefined ? Infinity : missionInfo[missionName]['time'];
 		if (time == null) return 'Invalid time';
 		else if (time >= maxTime) return `Time must be < mission's given time (${formatTime(maxTime)})`;
 		else if (time > 0) return true;

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Input from '$lib/controls/Input.svelte';
-	import type { FrontendUser, MissionPack } from '$lib/types';
+	import type { MissionPack } from '$lib/types';
 	import { getSteamID, validateSteamID } from '$lib/util';
 	import toast from 'svelte-french-toast';
 

--- a/src/routes/upload/_types.ts
+++ b/src/routes/upload/_types.ts
@@ -1,3 +1,3 @@
 import type { MissionWithPack } from '$lib/types';
 
-export type ReplaceableMission = MissionWithPack & { replace: boolean };
+export type ReplaceableMission = MissionWithPack & { replace: boolean; ids: string[] };

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -53,6 +53,7 @@ export async function POST({ locals, request }: RequestEvent) {
 				logfile: mission.logfile,
 				dateAdded: mission.dateAdded,
 				uploadedBy: locals.user.id,
+				inGameId: mission.inGameId,
 				verified: false
 			}
 		});

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -25,6 +25,7 @@ export const load = async function ({ parent, params }: any) {
 			solo: true,
 			dateAdded: true,
 			first: true,
+			time: true,
 			mission: {
 				select: {
 					name: true,
@@ -50,18 +51,22 @@ export const load = async function ({ parent, params }: any) {
 					solo: true,
 					dateAdded: true,
 					first: true,
-					time: true
+					time: true,
+					old: true,
+					mission: {
+						select: { name: true }
+					}
 				},
 				where: {
-					team: { has: params.user },
 					verified: true
 				},
-				orderBy: { time: 'asc' },
+				orderBy: { time: 'desc' },
 				take: 1
 			},
 			name: true,
 			id: true
-		}
+		},
+		orderBy: { name: 'asc' }
 	});
 	let unverifSolves: any[] | null = null;
 	let unverifMissions: any[] | null = null;
@@ -183,7 +188,9 @@ export const load = async function ({ parent, params }: any) {
 						};
 				  }),
 		unverifPacks,
-		bestTimes: bestTimes.filter(miss => miss.completions.length > 0 && miss.completions[0].team.includes(params.user)),
+		bestTimes: bestTimes
+			.filter(miss => miss.completions.length > 0 && miss.completions[0].team.includes(params.user))
+			.map(miss => miss.completions[0]),
 		stats: {
 			distinct: completer.distinct.size,
 			defuser: completer.defuser.size,

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -15,7 +15,8 @@ export const load = async function ({ parent, params }: any) {
 		select: {
 			avatar: true,
 			username: true,
-			permissions: true
+			permissions: true,
+			id: true
 		}
 	});
 

--- a/src/routes/user/[user]/+page.svelte
+++ b/src/routes/user/[user]/+page.svelte
@@ -10,6 +10,9 @@
 	import { browser } from '$app/environment';
 	import { writable } from 'svelte/store';
 	import { TP_TEAM } from '$lib/const';
+	import type { Completion, MissionPack } from '@prisma/client';
+	import CompletionCard from '$lib/cards/CompletionCard.svelte';
+	import MissionCard from '$lib/cards/MissionCard.svelte';
 	export let data;
 
 	type SolveStats = {
@@ -26,6 +29,10 @@
 	let shownUser: FrontendUser | null = data.shownUser;
 	let completions: MissionCompletion[] = data.completions;
 	let tpMissions: Mission[] = data.tpMissions;
+	let unverifSolves: (Completion & { mission: Mission })[] | null = data.unverifSolves;
+	let unverifMissions: Mission[] | null = data.unverifMissions;
+	let unverifPacks: MissionPack[] | null = data.unverifPacks;
+	let bestTimes: Mission[] = data.bestTimes;
 
 	const dateOptions: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
 	let newUsername = username;
@@ -206,6 +213,33 @@
 	<b class="block">Expert: {stats.expert}</b>
 	<b class="block">EFM: {stats.efm}</b>
 </div>
+
+{#if unverifSolves !== null}
+	<div class="block gray"><h4>Unverified Solves</h4></div>
+	{#each unverifSolves as comp}
+		<div class="unverif-item completion">
+			<CompletionCard completion={comp} />
+			<MissionCard mission={comp.mission} />
+		</div>
+	{/each}
+{/if}
+{#if unverifMissions !== null}
+	<div class="block gray"><h4>Unverified Missions</h4></div>
+	{#each unverifMissions as miss}
+		<MissionCard mission={miss} selectable nolink />
+	{/each}
+{/if}
+{#if unverifPacks !== null}
+	<div class="block gray"><h4>Unverified Mission Packs</h4></div>
+	{#each unverifPacks as pack}
+		<div class="block flex">
+			<a class="unverif-pack" href="https://steamcommunity.com/sharedfiles/filedetails/?id={pack.steamId}"
+				>{pack.name}</a>
+		</div>
+	{/each}
+{/if}
+
+<div class="block"><h2>Solves</h2></div>
 <div class="block legend-bar flex">
 	<div class="legend flex">
 		{#if tp}
@@ -220,7 +254,6 @@
 	</div>
 	<Select id="view-select" label="View:" sideLabel options={viewOptions} bind:value={viewMode} on:change={storeView} />
 </div>
-<div class="block"><h2>Solves</h2></div>
 {#if render && viewMode == viewOptions[2]}
 	<div class="solves role flex grow">
 		{#each completionByNewest as comp}
@@ -346,8 +379,11 @@
 		align-content: start;
 		white-space: nowrap;
 	}
-	a {
+	a:not(.unverif-pack) {
 		text-decoration: none;
+	}
+	a.unverif-pack {
+		color: var(--text-color);
 	}
 	a span.mission-name {
 		text-decoration: underline;
@@ -358,5 +394,14 @@
 	.newest {
 		justify-content: space-between;
 		gap: 20px;
+	}
+
+	.unverif-item.completion {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--gap);
+	}
+	.block.gray {
+		background-color: var(--accent-gray);
 	}
 </style>


### PR DESCRIPTION
1. Display not yet verified uploads on your profile, visible only by you. #104 
2. First Solves and Top Times show up user pages #97 
3. Fix ranking numbers for equal solve counts #30 
4. Add in-game Mission ID to mission class so this can be looked up in the missions endpoints, now required on uploading a new mission. This ID string is visible on the mission page to VerifyMission users only
5. Fix bugs with uploads of solves (calculating time incorrectly for "Factory: Sequence" / "Time Mode: Global" missions), and missions (detecting time mode and strike mode)
6. add inGameName to Missions so logfiles containing unexpected mission names can be parsed properly, this can also be looked up in the missions endpoints.