### PR TITLE
Add an audit log for various user actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "ktane-bombs",
 			"version": "0.0.1",
 			"dependencies": {
-				"@prisma/client": "^3.13.0",
+				"@prisma/client": "^4.16.2",
 				"@sveltejs/adapter-auto": "^1.0.0-next.80",
 				"cookie": "^0.5.0",
 				"discord-oauth2": "^2.11.0",
@@ -26,7 +26,7 @@
 				"eslint-plugin-svelte3": "^4.0.0",
 				"prettier": "^2.5.1",
 				"prettier-plugin-svelte": "^2.5.0",
-				"prisma": "^3.15.2",
+				"prisma": "^4.16.2",
 				"svelte": "^3.44.0",
 				"svelte-check": "^2.2.6",
 				"svelte-preprocess": "^4.10.1",
@@ -199,14 +199,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@prisma/client": {
-			"version": "3.15.2",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.2.tgz",
+			"integrity": "sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==",
 			"hasInstallScript": true,
-			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/engines-version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+				"@prisma/engines-version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
 			},
 			"engines": {
-				"node": ">=12.6"
+				"node": ">=14.17"
 			},
 			"peerDependencies": {
 				"prisma": "*"
@@ -218,14 +219,16 @@
 			}
 		},
 		"node_modules/@prisma/engines": {
-			"version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.2.tgz",
+			"integrity": "sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==",
 			"devOptional": true,
-			"hasInstallScript": true,
-			"license": "Apache-2.0"
+			"hasInstallScript": true
 		},
 		"node_modules/@prisma/engines-version": {
-			"version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e",
-			"license": "Apache-2.0"
+			"version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
+			"integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg=="
 		},
 		"node_modules/@rollup/plugin-commonjs": {
 			"version": "23.0.7",
@@ -2311,20 +2314,20 @@
 			}
 		},
 		"node_modules/prisma": {
-			"version": "3.15.2",
-			"resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.2.tgz",
-			"integrity": "sha512-nMNSMZvtwrvoEQ/mui8L/aiCLZRCj5t6L3yujKpcDhIPk7garp8tL4nMx2+oYsN0FWBacevJhazfXAbV1kfBzA==",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.2.tgz",
+			"integrity": "sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@prisma/engines": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+				"@prisma/engines": "4.16.2"
 			},
 			"bin": {
 				"prisma": "build/index.js",
 				"prisma2": "build/index.js"
 			},
 			"engines": {
-				"node": ">=12.6"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/prisma-exclude": {
@@ -3213,17 +3216,23 @@
 			"dev": true
 		},
 		"@prisma/client": {
-			"version": "3.15.2",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.2.tgz",
+			"integrity": "sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==",
 			"requires": {
-				"@prisma/engines-version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+				"@prisma/engines-version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
 			}
 		},
 		"@prisma/engines": {
-			"version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.2.tgz",
+			"integrity": "sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==",
 			"devOptional": true
 		},
 		"@prisma/engines-version": {
-			"version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+			"version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
+			"integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg=="
 		},
 		"@rollup/plugin-commonjs": {
 			"version": "23.0.7",
@@ -4491,12 +4500,12 @@
 			"requires": {}
 		},
 		"prisma": {
-			"version": "3.15.2",
-			"resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.2.tgz",
-			"integrity": "sha512-nMNSMZvtwrvoEQ/mui8L/aiCLZRCj5t6L3yujKpcDhIPk7garp8tL4nMx2+oYsN0FWBacevJhazfXAbV1kfBzA==",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.2.tgz",
+			"integrity": "sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==",
 			"devOptional": true,
 			"requires": {
-				"@prisma/engines": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+				"@prisma/engines": "4.16.2"
 			}
 		},
 		"prisma-exclude": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"eslint-plugin-svelte3": "^4.0.0",
 		"prettier": "^2.5.1",
 		"prettier-plugin-svelte": "^2.5.0",
-		"prisma": "^3.15.2",
+		"prisma": "^4.16.2",
 		"svelte": "^3.44.0",
 		"svelte-check": "^2.2.6",
 		"svelte-preprocess": "^4.10.1",
@@ -31,7 +31,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@prisma/client": "^3.13.0",
+		"@prisma/client": "^4.16.2",
 		"@sveltejs/adapter-auto": "^1.0.0-next.80",
 		"cookie": "^0.5.0",
 		"discord-oauth2": "^2.11.0",

--- a/prisma/migrations/20240714124037_add_audit_log/migration.sql
+++ b/prisma/migrations/20240714124037_add_audit_log/migration.sql
@@ -5,6 +5,7 @@ CREATE TABLE "AuditLog" (
     "model" TEXT NOT NULL,
     "recordId" TEXT NOT NULL,
     "action" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
     "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "before" JSONB,
     "after" JSONB,

--- a/prisma/migrations/20240714124037_add_audit_log/migration.sql
+++ b/prisma/migrations/20240714124037_add_audit_log/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" SERIAL NOT NULL,
+    "userId" TEXT,
+    "model" TEXT NOT NULL,
+    "recordId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "before" JSONB,
+    "after" JSONB,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   accessToken  String
   refreshToken String
   permissions  Int[]
+  logs         AuditLog[]
 }
 
 model MissionPack {
@@ -79,4 +80,16 @@ model Completion {
   missionId Int
 
   verified Boolean @default(true)
+}
+
+model AuditLog {
+  id	Int @id @default(autoincrement())
+  userId String?
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+  model String
+  recordId String
+  action String
+  timestamp DateTime @default(now())
+  before Json?
+  after Json?
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,20 +76,21 @@ model Completion {
   dateAdded    DateTime?
   uploadedBy   String?
 
-  mission   Mission @relation(fields: [missionId], references: [id], onDelete: Cascade)
-  missionId Int
+  mission      Mission @relation(fields: [missionId], references: [id], onDelete: Cascade)
+  missionId    Int
 
-  verified Boolean @default(true)
+  verified     Boolean @default(true)
 }
 
 model AuditLog {
-  id	Int @id @default(autoincrement())
-  userId String?
-  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
-  model String
-  recordId String
-  action String
-  timestamp DateTime @default(now())
-  before Json?
-  after Json?
+  id	       Int @id @default(autoincrement())
+  userId     String?
+  user       User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+  model      String
+  recordId   String
+  name       String
+  action     String
+  timestamp  DateTime @default(now())
+  before     Json?
+  after      Json?
 }

--- a/src/lib/auditlog.ts
+++ b/src/lib/auditlog.ts
@@ -1,238 +1,237 @@
 import client from '$lib/client';
 import { FrontendUser } from '$lib/types';
 
-function diff(beforeObject: any, afterObject: any){
-	const before: {[id: string] : any} = {}
-	const after: {[id: string] : any} = {}
+function diff(beforeObject: any, afterObject: any) {
+	const before: { [id: string]: any } = {};
+	const after: { [id: string]: any } = {};
 	for (const key in afterObject) {
-		if (beforeObject[key] != afterObject[key]) {
-			before[key] = beforeObject[key]
-			after[key] = afterObject[key]
+		if (JSON.stringify(beforeObject[key]) != JSON.stringify(afterObject[key])) {
+			console.log(`key: ${key}`);
+			console.log(`before: ${beforeObject[key]}`);
+			console.log(`after: ${afterObject[key]}`);
+			before[key] = beforeObject[key];
+			after[key] = afterObject[key];
 		}
 	}
-	return [before, after]
+	console.log('');
+	return [before, after];
 }
 
-const auditTables: {[id: string] : any} = {
+const auditTables: { [id: string]: any } = {
 	Completion: client.completion,
 	Mission: client.mission,
 	MissionPack: client.missionPack,
 	User: client.user
+};
+
+function findName(record: any, model: string): string {
+	if (model === 'Completion')
+		return (
+			(record.mission ? record.mission.name : 'Unknown') + '||' + (record.team ? record.team.join(', ') : 'Unknown')
+		);
+	else if (model === 'User') return record.username ?? 'Unknown';
+	return record.name ?? 'Unknown';
 }
 
-const auditOperations: {[id: string] : any} = {
+const auditOperations: { [id: string]: any } = {
 	async update(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const record = await modelObject.findFirst({where: args.where})
+		const record = await modelObject.findFirst({ where: args.where });
 
-		const [before, after] = diff(record, args.data)
+		const [before, after] = diff(record, args.data);
+		let name = findName(record, model);
 
-		await client.auditLog.create(
-			{
+		if (Object.keys(before).length > 0 || Object.keys(after).length > 0)
+			await client.auditLog.create({
 				data: {
 					userId: user.id,
 					model: model,
 					recordId: record.id.toString(),
+					name: name,
 					action: 'update',
 					before: before,
 					after: after
 				}
-			}
-		)
+			});
 
-		return query(args)
+		return query(args);
 	},
 	async delete(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const record = await modelObject.findFirst({where: args.where})
+		const record = await modelObject.findFirst({ where: args.where });
+		let name = findName(record, model);
 
-		await client.auditLog.create(
-			{
+		await client.auditLog.create({
+			data: {
+				userId: user.id,
+				model: model,
+				recordId: record.id.toString(),
+				name: record.name,
+				action: 'delete',
+				before: record
+			}
+		});
+
+		return query(args);
+	},
+	async deleteMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const records = await modelObject.findMany({ where: args.where });
+
+		for (const record of records) {
+			let name = findName(record, model);
+			await client.auditLog.create({
 				data: {
 					userId: user.id,
 					model: model,
 					recordId: record.id.toString(),
+					name: record.name,
 					action: 'delete',
 					before: record
 				}
-			}
-		)
-
-		return query(args)
-	},
-	async deleteMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const records = await modelObject.findMany({where: args.where})
-
-		for (const record of records) {
-			
-			await client.auditLog.create(
-				{
-					data: {
-						userId: user.id,
-						model: model,
-						recordId: record.id.toString(),
-						action: 'delete',
-						before: record
-					}
-				}
-			)
+			});
 		}
 
-		return query(args)
+		return query(args);
 	},
 	async updateMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const records = await modelObject.findMany({where: args.where})
+		const records = await modelObject.findMany({ where: args.where });
 
 		for (const record of records) {
-			
-			const [before, after] = diff(record, args.data)
+			const [before, after] = diff(record, args.data);
+			let name = findName(record, model);
 
-			await client.auditLog.create(
-				{
+			if (Object.keys(before).length > 0 || Object.keys(after).length > 0)
+				await client.auditLog.create({
 					data: {
 						userId: user.id,
 						model: model,
 						recordId: record.id.toString(),
+						name: record.name,
 						action: 'update',
 						before: before,
 						after: after
 					}
-				}
-			)
+				});
 		}
 
-		return query(args)
+		return query(args);
 	},
 	async create(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const record = await query(args)
+		const record = await query(args);
+		let name = findName(record, model);
 
-		await client.auditLog.create(
-			{
+		await client.auditLog.create({
+			data: {
+				userId: user.id,
+				model: model,
+				recordId: record.id.toString(),
+				name: record.name,
+				action: 'create'
+				// after: record
+			}
+		});
+
+		return record;
+	},
+	async upsert(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await modelObject.findFirst({ where: args.where });
+		let name = findName(record, model);
+
+		if (record) {
+			//update
+			const [before, after] = diff(record, args.update);
+
+			if (Object.keys(before).length > 0 || Object.keys(after).length > 0)
+				await client.auditLog.create({
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						name: record.name,
+						action: 'update',
+						before: before,
+						after: after
+					}
+				});
+
+			return query(args);
+		} else {
+			//create
+
+			const record = await query(args);
+
+			await client.auditLog.create({
 				data: {
 					userId: user.id,
 					model: model,
 					recordId: record.id.toString(),
+					name: record.name,
 					action: 'create',
 					after: record
 				}
-			}
-		)
+			});
 
-		return record
-	},
-	async upsert(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const record = await modelObject.findFirst({where: args.where})
-		
-		if (record) {
-			//update
-			const [before, after] = diff(record, args.update)
-
-			await client.auditLog.create(
-				{
-					data: {
-						userId: user.id,
-						model: model,
-						recordId: record.id.toString(),
-						action: 'update',
-						before: before,
-						after: after
-					}
-				}
-			)
-
-			
-			return query(args)
-		}
-		else {
-			//create
-
-			const record = await query(args)
-
-			await client.auditLog.create(
-				{
-					data: {
-						userId: user.id,
-						model: model,
-						recordId: record.id.toString(),
-						action: 'create',
-						after: record
-					}
-				}
-			)
-
-			return record
+			return record;
 		}
 	}
-}
+};
 
 function createAuditClient(user: FrontendUser | null) {
-	return client.$extends(
-		{
-			name: 'Audit Log',
-			query: {
-				$allModels: {
-					async $allOperations( { model, operation, args, query }) {
-						if (!user || !model) return query(args);
+	return client.$extends({
+		name: 'Audit Log',
+		query: {
+			$allModels: {
+				async $allOperations({ model, operation, args, query }) {
+					if (!user || !model) return query(args);
 
-						if (!auditTables[model] || !auditOperations[operation]) return query(args);
+					if (!auditTables[model] || !auditOperations[operation]) return query(args);
 
-						return await auditOperations[operation](user, auditTables[model], model, args, query)
-					}
+					return await auditOperations[operation](user, auditTables[model], model, args, query);
 				}
-			},
-			model: {
-				auditLog: {
-					async fromUser(userId: string) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									userId: userId
-								}
-							}
-						)
-					},
-					async forCompletion(completionId: number) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'Completion',
-									recordId: completionId.toString()
-								}
-							}
-						)
-					},
-					async forMission(missionId: number) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'Mission',
-									recordId: missionId.toString()
-								}
-							}
-						)
-					},
-					async forMissionPack(missionPackId: number) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'Missionpack',
-									recordId: missionPackId.toString()
-								}
-							}
-						)
-					},
-					async forUser(userId: string) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'User',
-									recordId: userId
-								}
-							}
-						)
-					}
+			}
+		},
+		model: {
+			auditLog: {
+				async fromUser(userId: string) {
+					return await client.auditLog.findMany({
+						where: {
+							userId: userId
+						}
+					});
+				},
+				async forCompletion(completionId: number) {
+					return await client.auditLog.findMany({
+						where: {
+							model: 'Completion',
+							recordId: completionId.toString()
+						}
+					});
+				},
+				async forMission(missionId: number) {
+					return await client.auditLog.findMany({
+						where: {
+							model: 'Mission',
+							recordId: missionId.toString()
+						}
+					});
+				},
+				async forMissionPack(missionPackId: number) {
+					return await client.auditLog.findMany({
+						where: {
+							model: 'Missionpack',
+							recordId: missionPackId.toString()
+						}
+					});
+				},
+				async forUser(userId: string) {
+					return await client.auditLog.findMany({
+						where: {
+							model: 'User',
+							recordId: userId
+						}
+					});
 				}
 			}
 		}
-	)
+	});
 }
 
-export default createAuditClient
+export default createAuditClient;

--- a/src/lib/auditlog.ts
+++ b/src/lib/auditlog.ts
@@ -163,7 +163,7 @@ const auditOperations: {[id: string] : any} = {
 	}
 }
 
-function auditClient(user: FrontendUser | null) {
+function createAuditClient(user: FrontendUser | null) {
 	return client.$extends(
 		{
 			name: 'Audit Log',
@@ -235,4 +235,4 @@ function auditClient(user: FrontendUser | null) {
 	)
 }
 
-export default auditClient
+export default createAuditClient

--- a/src/lib/auditlog.ts
+++ b/src/lib/auditlog.ts
@@ -1,0 +1,238 @@
+import client from '$lib/client';
+import { FrontendUser } from '$lib/types';
+
+function diff(beforeObject: any, afterObject: any){
+	const before: {[id: string] : any} = {}
+	const after: {[id: string] : any} = {}
+	for (const key in afterObject) {
+		if (beforeObject[key] != afterObject[key]) {
+			before[key] = beforeObject[key]
+			after[key] = afterObject[key]
+		}
+	}
+	return [before, after]
+}
+
+const auditTables: {[id: string] : any} = {
+	Completion: client.completion,
+	Mission: client.mission,
+	MissionPack: client.missionPack,
+	User: client.user
+}
+
+const auditOperations: {[id: string] : any} = {
+	async update(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await modelObject.findFirst({where: args.where})
+
+		const [before, after] = diff(record, args.data)
+
+		await client.auditLog.create(
+			{
+				data: {
+					userId: user.id,
+					model: model,
+					recordId: record.id.toString(),
+					action: 'update',
+					before: before,
+					after: after
+				}
+			}
+		)
+
+		return query(args)
+	},
+	async delete(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await modelObject.findFirst({where: args.where})
+
+		await client.auditLog.create(
+			{
+				data: {
+					userId: user.id,
+					model: model,
+					recordId: record.id.toString(),
+					action: 'delete',
+					before: record
+				}
+			}
+		)
+
+		return query(args)
+	},
+	async deleteMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const records = await modelObject.findMany({where: args.where})
+
+		for (const record of records) {
+			
+			await client.auditLog.create(
+				{
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						action: 'delete',
+						before: record
+					}
+				}
+			)
+		}
+
+		return query(args)
+	},
+	async updateMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const records = await modelObject.findMany({where: args.where})
+
+		for (const record of records) {
+			
+			const [before, after] = diff(record, args.data)
+
+			await client.auditLog.create(
+				{
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						action: 'update',
+						before: before,
+						after: after
+					}
+				}
+			)
+		}
+
+		return query(args)
+	},
+	async create(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await query(args)
+
+		await client.auditLog.create(
+			{
+				data: {
+					userId: user.id,
+					model: model,
+					recordId: record.id.toString(),
+					action: 'create',
+					after: record
+				}
+			}
+		)
+
+		return record
+	},
+	async upsert(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await modelObject.findFirst({where: args.where})
+		
+		if (record) {
+			//update
+			const [before, after] = diff(record, args.update)
+
+			await client.auditLog.create(
+				{
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						action: 'update',
+						before: before,
+						after: after
+					}
+				}
+			)
+
+			
+			return query(args)
+		}
+		else {
+			//create
+
+			const record = await query(args)
+
+			await client.auditLog.create(
+				{
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						action: 'create',
+						after: record
+					}
+				}
+			)
+
+			return record
+		}
+	}
+}
+
+function auditClient(user: FrontendUser | null) {
+	return client.$extends(
+		{
+			name: 'Audit Log',
+			query: {
+				$allModels: {
+					async $allOperations( { model, operation, args, query }) {
+						if (!user || !model) return query(args);
+
+						if (!auditTables[model] || !auditOperations[operation]) return query(args);
+
+						return await auditOperations[operation](user, auditTables[model], model, args, query)
+					}
+				}
+			},
+			model: {
+				auditLog: {
+					async fromUser(userId: string) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									userId: userId
+								}
+							}
+						)
+					},
+					async forBomb(bombId: number) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'bomb',
+									recordId: bombId.toString()
+								}
+							}
+						)
+					},
+					async forCompletion(completionId: number) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'completion',
+									recordId: completionId.toString()
+								}
+							}
+						)
+					},
+					async forMission(missionId: number) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'mission',
+									recordId: missionId.toString()
+								}
+							}
+						)
+					},
+					async forMissionPack(missionPackId: number) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'missionpack',
+									recordId: missionPackId.toString()
+								}
+							}
+						)
+					}
+				}
+			}
+		}
+	)
+}
+
+export default auditClient

--- a/src/lib/auditlog.ts
+++ b/src/lib/auditlog.ts
@@ -189,21 +189,11 @@ function auditClient(user: FrontendUser | null) {
 							}
 						)
 					},
-					async forBomb(bombId: number) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'bomb',
-									recordId: bombId.toString()
-								}
-							}
-						)
-					},
 					async forCompletion(completionId: number) {
 						return await client.auditLog.findMany(
 							{
 								where: {
-									model: 'completion',
+									model: 'Completion',
 									recordId: completionId.toString()
 								}
 							}
@@ -213,7 +203,7 @@ function auditClient(user: FrontendUser | null) {
 						return await client.auditLog.findMany(
 							{
 								where: {
-									model: 'mission',
+									model: 'Mission',
 									recordId: missionId.toString()
 								}
 							}
@@ -223,8 +213,18 @@ function auditClient(user: FrontendUser | null) {
 						return await client.auditLog.findMany(
 							{
 								where: {
-									model: 'missionpack',
+									model: 'Missionpack',
 									recordId: missionPackId.toString()
+								}
+							}
+						)
+					},
+					async forUser(userId: string) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'User',
+									recordId: userId
 								}
 							}
 						)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -94,6 +94,7 @@
 		--needy-color: #9999ff;
 		--quirks-color: #aae8ff;
 		--stick-under-navbar: calc(1.25em + 4 * var(--gap) + 2px);
+		--page-content-width: min(calc(100vw - 4 * var(--gap)), 1150px);
 	}
 
 	@media (prefers-color-scheme: dark) {
@@ -317,7 +318,7 @@
 	}
 
 	.max-width {
-		width: min(calc(100vw - 4 * var(--gap)), 1150px);
+		width: var(--page-content-width);
 		margin: 0 auto;
 	}
 

--- a/src/routes/auditlog/+page.server.ts
+++ b/src/routes/auditlog/+page.server.ts
@@ -1,0 +1,49 @@
+import client from '$lib/client';
+import { Permission } from '$lib/types';
+import { forbidden, hasAnyPermission } from '$lib/util';
+
+export const load = async function ({ parent, locals }: any) {
+	const { user } = await parent();
+	if (!hasAnyPermission(user, Permission.VerifyMission, Permission.VerifyCompletion, Permission.VerifyMissionPack)) {
+		throw forbidden(locals);
+	}
+
+	const everything = await client.auditLog.findMany({
+		orderBy: { id: 'asc' }
+	});
+
+	let logs: any[] = [];
+	for (let i = 0; i < everything.length; i++) {
+		let log = {
+			...everything[i],
+			linkable: false,
+			mission: null
+		};
+		if (log.userId != null) {
+			const usr = await client.user.findUnique({
+				where: { id: log.userId },
+				select: { username: true }
+			});
+			if (usr !== null) {
+				log.userId = usr.username;
+			}
+		}
+		logs.push(log);
+	}
+
+	return {
+		logs,
+		fromUser: null,
+		editMissions: null,
+		newMissions: null,
+		deleteMissions: null,
+		editPacks: null,
+		newPacks: null,
+		deletePacks: null,
+		editCompletions: null,
+		newCompletions: null,
+		deleteCompletions: null,
+		editUsers: null,
+		deleteUsers: null
+	};
+};

--- a/src/routes/auditlog/+page.svelte
+++ b/src/routes/auditlog/+page.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	import { isOnlyDigits, properUrlEncode } from '$lib/util.js';
+	import { AuditLog, Prisma } from '@prisma/client';
+
+	const dateOptions: Intl.DateTimeFormatOptions = {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit'
+	};
+
+	export let data;
+	let logs: AuditLog[] = data.logs;
+
+	function pastTense(log: AuditLog): string {
+		if (log.model === 'Mission' && (log.action === 'delete' || log.action === 'update')) {
+			const missonStatsBef = JSON.parse(JSON.stringify(log.before));
+			const missonStatsAft = JSON.parse(JSON.stringify(log.after));
+			if (log.action === 'delete' && missonStatsBef.verified === false) return 'rejected';
+			else if (log.action === 'update' && missonStatsBef.verified === false && missonStatsAft.verified === true)
+				return 'accepted';
+		}
+		return log.action + (log.action.endsWith('e') ? 'd' : 'ed');
+	}
+	function shortName(str: string): string {
+		if (str.length > 24) return str.substring(0, 24) + ' ...';
+		else return str;
+	}
+	function displayLog(js: Prisma.JsonValue) {
+		const str = JSON.stringify(js, undefined, 1);
+		const stats = JSON.parse(str);
+		if (stats == null || stats == undefined || Object.keys(stats).length == 0) return { short: '', full: '' };
+		return { short: str.substring(0, 250), full: str };
+	}
+
+	function reveal(before: boolean, index: number) {
+		let elem = document.querySelector(`.dropdown.${before ? 'before' : 'after'}${index}`);
+		elem?.classList.add('expand');
+	}
+	function hide(before: boolean, index: number) {
+		let elem = document.querySelector(`.dropdown.${before ? 'before' : 'after'}${index}`);
+		elem?.classList.remove('expand');
+	}
+	function closeAll() {
+		document.querySelectorAll('.dropdown:not(.small)').forEach(el => {
+			el.classList.remove('expand');
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>Audit Log</title>
+</svelte:head>
+<h1 class="header">Audit Log</h1>
+<div class="block">
+	<button on:click={closeAll}>Close All</button>
+</div>
+
+<div class="table">
+	<div class="block" />
+	<b class="block">Description</b>
+	<b class="block">Before</b>
+	<b class="block">After</b>
+	{#each logs as log, index}
+		<div class="block number">{index + 1}</div>
+		<div class="block">
+			{#if log.userId != null && !isOnlyDigits(log.userId)}
+				<a href="/user/{properUrlEncode(log.userId)}">{log.userId}</a>
+			{:else}
+				{log.userId}
+			{/if}
+			<br />
+			{pastTense(log)}
+			{log.model.toLowerCase()} <br />
+			{#if log.model === 'Mission'}
+				<a href="/mission/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+			{:else if log.model === 'Missionpack'}
+				<a href="/missionpack/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+			{:else if log.model === 'Completion'}
+				{@const names = log.name.split('||')}
+				{names[1]} on <br />
+				<a href="/mission/{properUrlEncode(names[0])}">{shortName(names[0])}</a>
+			{:else if log.model === 'User'}
+				<a href="/user/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+			{/if}
+			<br />
+			{log.timestamp.toLocaleDateString(undefined, dateOptions)}
+		</div>
+		{@const before = displayLog(log.before)}
+		<div
+			class="block dropdown before{index}"
+			class:small={before.full.length < 250}
+			class:expand={before.full.length < 250}>
+			<div class="short" on:click={() => reveal(true, index)}>
+				{before.short} <strong>...</strong>
+			</div>
+			<div class="full">
+				<div class="contract" on:click={() => hide(true, index)} />
+				{before.full}
+			</div>
+		</div>
+		{@const after = displayLog(log.after)}
+		<div
+			class="block dropdown after{index}"
+			class:small={after.full.length < 250}
+			class:expand={after.full.length < 250}>
+			<div class="short" on:click={() => reveal(false, index)}>
+				{after.short} <strong>...</strong>
+			</div>
+			<div class="full">
+				<div class="contract" on:click={() => hide(false, index)} />
+				{after.full}
+			</div>
+		</div>
+	{/each}
+</div>
+
+<style>
+	:root {
+		--cell-width: calc((var(--page-content-width) - 240px) / 2 - var(--gap));
+	}
+	.number {
+		font-size: 10px;
+		padding: 1px;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+	.table {
+		display: grid;
+		grid-template-columns: 30px 210px var(--cell-width) var(--cell-width);
+		gap: var(--gap);
+		text-align: center;
+		width: 100%;
+		overflow: hidden;
+	}
+	.table > div {
+		overflow-wrap: break-word;
+	}
+	.dropdown:not(.expand) {
+		cursor: pointer;
+	}
+	.dropdown:not(.expand) div.full,
+	.dropdown.expand div.short {
+		display: none;
+	}
+	.dropdown.small .contract {
+		display: none;
+	}
+	.contract {
+		background: url('$lib/img/clear-button.svg') right center no-repeat;
+		width: 1.25em;
+		height: 1.25em;
+		min-width: 1.25em;
+		display: inline-block;
+		vertical-align: middle;
+		cursor: pointer;
+	}
+</style>

--- a/src/routes/login-callback/+page.server.ts
+++ b/src/routes/login-callback/+page.server.ts
@@ -1,6 +1,6 @@
 import client from '$lib/client';
 import OAuth, { scope } from '$lib/oauth';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/index.js';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import type { Cookies } from '@sveltejs/kit';
 import type { TokenRequestResult } from 'discord-oauth2';
 import { redirect, error } from '@sveltejs/kit';

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { getData } from '$lib/repo';
 import { Completion, Permission, type ID } from '$lib/types';
 import { excludeArticleSort, forbidden, hasPermission, properUrlEncode } from '$lib/util';
@@ -96,10 +97,13 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.VerifyMission)) {
 			throw forbidden(locals);
 		}
+
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const mission = JSON.parse(fData.get('mission')?.toString() ?? '');
 
-		await client.mission.delete({
+		await userClient.mission.delete({
 			where: {
 				name: mission.name
 			}
@@ -111,10 +115,13 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.VerifyCompletion)) {
 			throw forbidden(locals);
 		}
+
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const completion: ID<Completion> = JSON.parse(fData.get('completion')?.toString() ?? '');
 
-		await client.completion.delete({
+		await userClient.completion.delete({
 			where: {
 				id: completion.id
 			}
@@ -126,6 +133,8 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.VerifyMission)) {
 			throw forbidden(locals);
 		}
+
+		const userClient = auditClient(locals.user)
 
 		const fData = await request.formData();
 		const mission: EditMission = JSON.parse(fData.get('mission')?.toString() ?? '');
@@ -158,7 +167,7 @@ export const actions: Actions = {
 				});
 				//if there is only one other, remove that one's variant ID too since you need at least 2 missions in a variant group
 				if (other.length == 1) {
-					await client.mission.update({
+					await userClient.mission.update({
 						where: {
 							id: other[0].id
 						},
@@ -187,7 +196,7 @@ export const actions: Actions = {
 					});
 					let max = Math.max(...variants.map(v => v.variant ?? -1));
 					mission.variant = max + 1;
-					await client.mission.update({
+					await userClient.mission.update({
 						where: {
 							id: selected.id
 						},
@@ -199,7 +208,7 @@ export const actions: Actions = {
 			}
 		}
 
-		await client.mission.update({
+		await userClient.mission.update({
 			where: {
 				id: mission.id
 			},
@@ -254,7 +263,9 @@ export async function POST({ locals, request }: RequestEvent) {
 
 	const mission: EditMission = await request.json();
 
-	await client.mission.update({
+	const userClient = auditClient(locals.user)
+
+	await userClient.mission.update({
 		where: {
 			id: mission.id
 		},
@@ -284,7 +295,9 @@ export async function DELETE({ locals, request }: RequestEvent) {
 
 	const completion: ID<Completion> = await request.json();
 
-	await client.completion.delete({
+	const userClient = auditClient(locals.user)
+
+	await userClient.completion.delete({
 		where: {
 			id: completion.id
 		}

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { getData } from '$lib/repo';
 import { Completion, Permission, type ID } from '$lib/types';
 import { excludeArticleSort, forbidden, hasPermission, properUrlEncode } from '$lib/util';
@@ -98,12 +98,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const mission = JSON.parse(fData.get('mission')?.toString() ?? '');
 
-		await userClient.mission.delete({
+		await auditClient.mission.delete({
 			where: {
 				name: mission.name
 			}
@@ -116,12 +116,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const completion: ID<Completion> = JSON.parse(fData.get('completion')?.toString() ?? '');
 
-		await userClient.completion.delete({
+		await auditClient.completion.delete({
 			where: {
 				id: completion.id
 			}
@@ -134,7 +134,7 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const mission: EditMission = JSON.parse(fData.get('mission')?.toString() ?? '');
@@ -167,7 +167,7 @@ export const actions: Actions = {
 				});
 				//if there is only one other, remove that one's variant ID too since you need at least 2 missions in a variant group
 				if (other.length == 1) {
-					await userClient.mission.update({
+					await auditClient.mission.update({
 						where: {
 							id: other[0].id
 						},
@@ -196,7 +196,7 @@ export const actions: Actions = {
 					});
 					let max = Math.max(...variants.map(v => v.variant ?? -1));
 					mission.variant = max + 1;
-					await userClient.mission.update({
+					await auditClient.mission.update({
 						where: {
 							id: selected.id
 						},
@@ -208,7 +208,7 @@ export const actions: Actions = {
 			}
 		}
 
-		await userClient.mission.update({
+		await auditClient.mission.update({
 			where: {
 				id: mission.id
 			},
@@ -263,9 +263,9 @@ export async function POST({ locals, request }: RequestEvent) {
 
 	const mission: EditMission = await request.json();
 
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
-	await userClient.mission.update({
+	await auditClient.mission.update({
 		where: {
 			id: mission.id
 		},
@@ -295,9 +295,9 @@ export async function DELETE({ locals, request }: RequestEvent) {
 
 	const completion: ID<Completion> = await request.json();
 
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
-	await userClient.completion.delete({
+	await auditClient.completion.delete({
 		where: {
 			id: completion.id
 		}

--- a/src/routes/missionpack/[missionpack]/edit/+page.server.ts
+++ b/src/routes/missionpack/[missionpack]/edit/+page.server.ts
@@ -56,7 +56,7 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const auditClient = createAuditClient(locals.user)
+		const auditClient = createAuditClient(locals.user);
 
 		const fData = await request.formData();
 		const pack = JSON.parse(fData.get('pack')?.toString() ?? '');
@@ -75,7 +75,7 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const auditClient = createAuditClient(locals.user)
+		const auditClient = createAuditClient(locals.user);
 
 		const fData = await request.formData();
 		const pack: EditMissionPack = JSON.parse(fData.get('pack')?.toString() ?? '');

--- a/src/routes/missionpack/[missionpack]/edit/+page.server.ts
+++ b/src/routes/missionpack/[missionpack]/edit/+page.server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import type { RequestEvent, ServerLoadEvent } from '@sveltejs/kit';
@@ -56,12 +56,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const pack = JSON.parse(fData.get('pack')?.toString() ?? '');
 
-		await userClient.missionPack.delete({
+		await auditClient.missionPack.delete({
 			where: {
 				name: pack.name
 			}
@@ -75,12 +75,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const pack: EditMissionPack = JSON.parse(fData.get('pack')?.toString() ?? '');
 
-		await userClient.missionPack.update({
+		await auditClient.missionPack.update({
 			where: {
 				id: pack.id
 			},

--- a/src/routes/missionpack/[missionpack]/edit/+page.server.ts
+++ b/src/routes/missionpack/[missionpack]/edit/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import type { RequestEvent, ServerLoadEvent } from '@sveltejs/kit';
@@ -54,10 +55,13 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.VerifyMissionPack)) {
 			throw forbidden(locals);
 		}
+
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const pack = JSON.parse(fData.get('pack')?.toString() ?? '');
 
-		await client.missionPack.delete({
+		await userClient.missionPack.delete({
 			where: {
 				name: pack.name
 			}
@@ -71,10 +75,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const pack: EditMissionPack = JSON.parse(fData.get('pack')?.toString() ?? '');
 
-		await client.missionPack.update({
+		await userClient.missionPack.update({
 			where: {
 				id: pack.id
 			},

--- a/src/routes/modules/+page.svelte
+++ b/src/routes/modules/+page.svelte
@@ -60,7 +60,7 @@
 		sortOption = 'published';
 		updateSearch();
 	}
-	function closeeAll() {
+	function closeAll() {
 		document.querySelectorAll('.missions-dropdown:not(.few)').forEach(el => {
 			el.classList.remove('expand');
 		});
@@ -109,7 +109,7 @@
 			bind:this={layoutSearch}
 			filterFunc={moduleSearchFilter}
 			classes="help" />
-		<button on:click={closeeAll}>Close All</button>
+		<button on:click={closeAll}>Close All</button>
 		<span class="sort-option alphabetical" class:selected={sortOption == 'alphabetical'} on:click={alphabetical}
 			>Alphabetical</span>
 		<span class="sort-option popular" class:selected={sortOption == 'popular'} on:click={popular}>Popular</span>

--- a/src/routes/upload/completion/+server.ts
+++ b/src/routes/upload/completion/+server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import type { Completion } from '$lib/types';
 import { forbidden } from '$lib/util';
 import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 	
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
 	const { completion, missionName }: { completion: Completion; missionName: string } = await request.json();
 	completion.uploadedBy = locals.user.id;
@@ -44,7 +44,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		//don't allow duplicate solve uploads that are already in the verify queue
 		return new Response(undefined, { status: 409 });
 
-	await userClient.completion.create({
+	await auditClient.completion.create({
 		data: {
 			...completion,
 			mission: {

--- a/src/routes/upload/completion/+server.ts
+++ b/src/routes/upload/completion/+server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import type { Completion } from '$lib/types';
 import { forbidden } from '$lib/util';
 import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
@@ -7,6 +8,9 @@ export async function POST({ locals, request }: RequestEvent) {
 	if (locals.user == null) {
 		throw forbidden(locals);
 	}
+	
+	const userClient = auditClient(locals.user)
+
 	const { completion, missionName }: { completion: Completion; missionName: string } = await request.json();
 	completion.uploadedBy = locals.user.id;
 	if (completion.team.length != 1 && completion.solo) {
@@ -40,7 +44,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		//don't allow duplicate solve uploads that are already in the verify queue
 		return new Response(undefined, { status: 409 });
 
-	await client.completion.create({
+	await userClient.completion.create({
 		data: {
 			...completion,
 			mission: {

--- a/src/routes/upload/completion/+server.ts
+++ b/src/routes/upload/completion/+server.ts
@@ -8,8 +8,8 @@ export async function POST({ locals, request }: RequestEvent) {
 	if (locals.user == null) {
 		throw forbidden(locals);
 	}
-	
-	const auditClient = createAuditClient(locals.user)
+
+	const auditClient = createAuditClient(locals.user);
 
 	const { completion, missionName }: { completion: Completion; missionName: string } = await request.json();
 	completion.uploadedBy = locals.user.id;

--- a/src/routes/upload/missionpack/+server.ts
+++ b/src/routes/upload/missionpack/+server.ts
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 
-	const auditClient = createAuditClient(locals.user)
+	const auditClient = createAuditClient(locals.user);
 
 	const pack: MissionPack = await request.json();
 	pack.uploadedBy = locals.user.id;

--- a/src/routes/upload/missionpack/+server.ts
+++ b/src/routes/upload/missionpack/+server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import type { MissionPack } from '$lib/types';
 import { forbidden } from '$lib/util';
 import type { RequestEvent } from '@sveltejs/kit';
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
 	const pack: MissionPack = await request.json();
 	pack.uploadedBy = locals.user.id;
@@ -27,7 +27,7 @@ export async function POST({ locals, request }: RequestEvent) {
 			return new Response('Mission pack is already in the queue for verfication.', { status: 409 });
 		else return new Response('Duplicate mission pack not uploaded.', { status: 406 });
 	}
-	await userClient.missionPack.create({
+	await auditClient.missionPack.create({
 		data: {
 			...pack,
 			verified: false

--- a/src/routes/upload/missionpack/+server.ts
+++ b/src/routes/upload/missionpack/+server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import type { MissionPack } from '$lib/types';
 import { forbidden } from '$lib/util';
 import type { RequestEvent } from '@sveltejs/kit';
@@ -7,6 +8,9 @@ export async function POST({ locals, request }: RequestEvent) {
 	if (locals.user == null) {
 		throw forbidden(locals);
 	}
+
+	const userClient = auditClient(locals.user)
+
 	const pack: MissionPack = await request.json();
 	pack.uploadedBy = locals.user.id;
 	let equalPack = await client.missionPack.findUnique({
@@ -23,7 +27,7 @@ export async function POST({ locals, request }: RequestEvent) {
 			return new Response('Mission pack is already in the queue for verfication.', { status: 409 });
 		else return new Response('Duplicate mission pack not uploaded.', { status: 406 });
 	}
-	await client.missionPack.create({
+	await userClient.missionPack.create({
 		data: {
 			...pack,
 			verified: false

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client'
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { error, type RequestEvent } from '@sveltejs/kit';
 import type { ReplaceableMission } from '../_types';
 import { forbidden } from '$lib/util';
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
 	const missions: ReplaceableMission[] = await request.json();
 	if (missions.some(m => m.missionPack === null)) {
@@ -37,7 +37,7 @@ export async function POST({ locals, request }: RequestEvent) {
 			if (!context.includes('R')) context += 'R';
 		} else if (!context.includes('N')) context += 'N';
 
-		await userClient.mission.create({
+		await auditClient.mission.create({
 			data: {
 				name: missionName,
 				authors: mission.authors,

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -1,4 +1,5 @@
-import client from '$lib/client';
+import client from '$lib/client'
+import auditClient from '$lib/auditlog';
 import { error, type RequestEvent } from '@sveltejs/kit';
 import type { ReplaceableMission } from '../_types';
 import { forbidden } from '$lib/util';
@@ -7,6 +8,9 @@ export async function POST({ locals, request }: RequestEvent) {
 	if (locals.user == null) {
 		throw forbidden(locals);
 	}
+
+	const userClient = auditClient(locals.user)
+
 	const missions: ReplaceableMission[] = await request.json();
 	if (missions.some(m => m.missionPack === null)) {
 		throw error(400, 'Mission pack is required.');
@@ -33,7 +37,7 @@ export async function POST({ locals, request }: RequestEvent) {
 			if (!context.includes('R')) context += 'R';
 		} else if (!context.includes('N')) context += 'N';
 
-		await client.mission.create({
+		await userClient.mission.create({
 			data: {
 				name: missionName,
 				authors: mission.authors,

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -1,4 +1,4 @@
-import client from '$lib/client'
+import client from '$lib/client';
 import createAuditClient from '$lib/auditlog';
 import { error, type RequestEvent } from '@sveltejs/kit';
 import type { ReplaceableMission } from '../_types';
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 
-	const auditClient = createAuditClient(locals.user)
+	const auditClient = createAuditClient(locals.user);
 
 	const missions: ReplaceableMission[] = await request.json();
 	if (missions.some(m => m.missionPack === null)) {

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -210,8 +210,8 @@ export const actions = {
 		if (!hasPermission(locals.user, Permission.ModifyPermissions)) {
 			return forbidden(locals);
 		}
-		
-		const auditClient = createAuditClient(locals.user)
+
+		const auditClient = createAuditClient(locals.user);
 
 		const fData = await request.formData();
 		const body: Permission[] = JSON.parse(fData.get('perms')?.toString() ?? '');

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { TP_TEAM } from '$lib/const';
 import { Permission } from '$lib/types';
 import { fixPools, forbidden, hasPermission } from '$lib/util';
@@ -209,13 +210,16 @@ export const actions = {
 		if (!hasPermission(locals.user, Permission.ModifyPermissions)) {
 			return forbidden(locals);
 		}
+		
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const body: Permission[] = JSON.parse(fData.get('perms')?.toString() ?? '');
 		const user = fData.get('user')?.toString();
 		if (user === null || user === undefined) {
 			throw error(400);
 		}
-		await client.user.update({
+		await userClient.user.update({
 			where: {
 				id: user
 			},

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { TP_TEAM } from '$lib/const';
 import { Permission } from '$lib/types';
 import { fixPools, forbidden, hasPermission } from '$lib/util';
@@ -211,7 +211,7 @@ export const actions = {
 			return forbidden(locals);
 		}
 		
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const body: Permission[] = JSON.parse(fData.get('perms')?.toString() ?? '');
@@ -219,7 +219,7 @@ export const actions = {
 		if (user === null || user === undefined) {
 			throw error(400);
 		}
-		await userClient.user.update({
+		await auditClient.user.update({
 			where: {
 				id: user
 			},

--- a/src/routes/user/rename/+server.ts
+++ b/src/routes/user/rename/+server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import type { RequestHandler } from '@sveltejs/kit';
@@ -8,7 +8,7 @@ import { redirect } from '@sveltejs/kit';
 export const POST: RequestHandler = async function ({ locals, request }) {
 	if (!hasPermission(locals.user, Permission.RenameUser)) forbidden(locals);
 	
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
 	const { oldUsername, username, nameExistsOK } = await request.json();
 
@@ -82,7 +82,7 @@ export const POST: RequestHandler = async function ({ locals, request }) {
 
 	if (user !== null && user !== undefined) {
 		// User
-		await userClient.user.update({
+		await auditClient.user.update({
 			where: {
 				username: oldUsername
 			},

--- a/src/routes/user/rename/+server.ts
+++ b/src/routes/user/rename/+server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import type { RequestHandler } from '@sveltejs/kit';
@@ -6,6 +7,8 @@ import { redirect } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async function ({ locals, request }) {
 	if (!hasPermission(locals.user, Permission.RenameUser)) forbidden(locals);
+	
+	const userClient = auditClient(locals.user)
 
 	const { oldUsername, username, nameExistsOK } = await request.json();
 
@@ -79,7 +82,7 @@ export const POST: RequestHandler = async function ({ locals, request }) {
 
 	if (user !== null && user !== undefined) {
 		// User
-		await client.user.update({
+		await userClient.user.update({
 			where: {
 				username: oldUsername
 			},

--- a/src/routes/user/rename/+server.ts
+++ b/src/routes/user/rename/+server.ts
@@ -7,8 +7,8 @@ import { redirect } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async function ({ locals, request }) {
 	if (!hasPermission(locals.user, Permission.RenameUser)) forbidden(locals);
-	
-	const auditClient = createAuditClient(locals.user)
+
+	const auditClient = createAuditClient(locals.user);
 
 	const { oldUsername, username, nameExistsOK } = await request.json();
 

--- a/src/routes/users/rename/+page.server.ts
+++ b/src/routes/users/rename/+page.server.ts
@@ -30,8 +30,8 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.RenameUser)) {
 			throw forbidden(locals);
 		}
-		
-		const auditClient = createAuditClient(locals.user)
+
+		const auditClient = createAuditClient(locals.user);
 
 		const fData = await request.formData();
 		const oldUsername: string = JSON.parse(fData.get('oldUsername')?.toString() ?? '');

--- a/src/routes/users/rename/+page.server.ts
+++ b/src/routes/users/rename/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import { redirect, type RequestEvent } from '@sveltejs/kit';
@@ -29,6 +30,8 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.RenameUser)) {
 			throw forbidden(locals);
 		}
+		
+		const userClient = auditClient(locals.user)
 
 		const fData = await request.formData();
 		const oldUsername: string = JSON.parse(fData.get('oldUsername')?.toString() ?? '');
@@ -42,7 +45,7 @@ export const actions: Actions = {
 
 		if (user !== null && user !== undefined) {
 			// User
-			await client.user.update({
+			await userClient.user.update({
 				where: {
 					username: oldUsername
 				},

--- a/src/routes/users/rename/+page.server.ts
+++ b/src/routes/users/rename/+page.server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import { redirect, type RequestEvent } from '@sveltejs/kit';
@@ -31,7 +31,7 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 		
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const oldUsername: string = JSON.parse(fData.get('oldUsername')?.toString() ?? '');
@@ -45,7 +45,7 @@ export const actions: Actions = {
 
 		if (user !== null && user !== undefined) {
 			// User
-			await userClient.user.update({
+			await auditClient.user.update({
 				where: {
 					username: oldUsername
 				},

--- a/src/routes/verify/+page.svelte
+++ b/src/routes/verify/+page.svelte
@@ -61,7 +61,10 @@
 	<title>Verify Queue</title>
 </svelte:head>
 
-<h1 class="header">Verify Queue</h1>
+<div class="block top-bar">
+	<a class="audit-log" href="/auditlog">Audit Log</a>
+	<h1 class="header">Verify Queue</h1>
+</div>
 
 <div class="flex column">
 	{#each queue as item, index (item)}
@@ -111,5 +114,14 @@
 	}
 	:is(span, .block).red {
 		color: red;
+	}
+
+	.top-bar {
+		position: relative;
+	}
+	.audit-log {
+		position: absolute;
+		top: var(--gap);
+		left: var(--gap);
 	}
 </style>

--- a/src/routes/verify/item/+server.ts
+++ b/src/routes/verify/item/+server.ts
@@ -8,7 +8,7 @@ import { TP_TEAM } from '$lib/const';
 export const POST: RequestHandler = async function ({ locals, request }: RequestEvent) {
 	const { accept, item, replaceId }: { accept: boolean; item: QueueItem; replaceId: number } = await request.json();
 
-	const client = asUser(locals.user)
+	const client = asUser(locals.user);
 	switch (item.type) {
 		case 'mission':
 			if (!hasPermission(locals.user, Permission.VerifyMission)) {

--- a/src/routes/verify/item/+server.ts
+++ b/src/routes/verify/item/+server.ts
@@ -1,4 +1,4 @@
-import client from '$lib/client';
+import asUser from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import type { QueueItem } from '$lib/types';
 import { forbidden, hasPermission } from '$lib/util';
@@ -7,6 +7,8 @@ import { TP_TEAM } from '$lib/const';
 
 export const POST: RequestHandler = async function ({ locals, request }: RequestEvent) {
 	const { accept, item, replaceId }: { accept: boolean; item: QueueItem; replaceId: number } = await request.json();
+
+	const client = asUser(locals.user)
 	switch (item.type) {
 		case 'mission':
 			if (!hasPermission(locals.user, Permission.VerifyMission)) {


### PR DESCRIPTION
### Requires Node 14+, if our node version is not there then we need to upgrade node before this

Upgrades Prisma to major version 4 which allow for client extensions. Prisma 4 only requires node 14+.

Adds an AuditLog model which is used to track various create/update/delete events done by users.

Uses the client extensions to make an auditClient which accepts a FrontendUser/null arg and returns the extended client.

Extended auditClient has functions for searching the auditLog by user or modifications to various audited tables.

Extended auditClient will log the actions of specific CRUD operations by users to the auditLog. Including differences between the old record and the new one.