### PR TITLE
Auditlog

### DIFF
--- a/importer/advanced.json
+++ b/importer/advanced.json
@@ -1,0 +1,168 @@
+{
+	"AuditLog": [
+		{
+			"id": 146,
+			"userId": "688220820945895424",
+			"model": "MissionPack",
+			"recordId": "183",
+			"name": "rf",
+			"action": "create",
+			"timestamp": "2024-08-26T04:12:11.828Z"
+		},
+		{
+			"id": 147,
+			"userId": "688220820945895424",
+			"model": "MissionPack",
+			"recordId": "183",
+			"name": "rf",
+			"action": "update",
+			"timestamp": "2024-08-26T04:13:10.432Z",
+			"before": { "dateAdded": "2024-08-26T04:12:06.614Z" },
+			"after": { "dateAdded": "2024-08-20T12:00:00.000Z" }
+		},
+		{
+			"id": 148,
+			"userId": "688220820945895424",
+			"model": "MissionPack",
+			"recordId": "183",
+			"name": "rf",
+			"action": "update",
+			"timestamp": "2024-08-26T04:15:02.387Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 149,
+			"model": "MissionPack",
+			"recordId": "183",
+			"name": "rf",
+			"action": "delete",
+			"timestamp": "2024-08-26T04:15:38.763Z",
+			"before": {
+				"id": 183,
+				"name": "rf",
+				"steamId": "12345",
+				"verified": false,
+				"dateAdded": "2024-08-20T12:00:00.000Z",
+				"uploadedBy": "688220820945895424"
+			}
+		},
+		{
+			"id": 150,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "1127",
+			"name": "The Yoloist",
+			"action": "create",
+			"timestamp": "2024-08-26T04:16:29.958Z"
+		},
+		{
+			"id": 151,
+			"userId": "688220820945895424",
+			"model": "Completion",
+			"recordId": "7633",
+			"name": "Series of Similarities||LuminoscityTim",
+			"action": "create",
+			"timestamp": "2024-08-26T04:17:10.550Z"
+		},
+		{
+			"id": 152,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "1127",
+			"name": "The Yoloist",
+			"action": "delete",
+			"timestamp": "2024-08-26T05:28:24.132Z",
+			"before": {
+				"id": 1127,
+				"name": "The Yoloist",
+				"notes": null,
+				"authors": ["LuminoscityTim"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=251c07721ead29361e6f3ca3611059c526d0a3e5",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_bioplaysBombs_Yoloist",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-08-26T04:16:17.211Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "688220820945895424",
+				"designedForTP": false,
+				"missionPackId": 25
+			}
+		},
+		{
+			"id": 153,
+			"model": "MissionPack",
+			"recordId": "184",
+			"name": "rf",
+			"action": "create",
+			"timestamp": "2024-08-26T05:36:16.804Z"
+		},
+		{
+			"id": 154,
+			"model": "Completion",
+			"recordId": "5943",
+			"name": "Silence Madness||Macanek, Asmir",
+			"action": "update",
+			"timestamp": "2024-08-26T07:13:33.780Z",
+			"before": { "solo": false },
+			"after": { "solo": true }
+		},
+		{
+			"id": 155,
+			"userId": "688220820945895424",
+			"model": "Completion",
+			"recordId": "5943",
+			"name": "Silence Madness||Macanek, Asmir",
+			"action": "update",
+			"timestamp": "2024-08-26T07:13:46.165Z",
+			"before": { "solo": true },
+			"after": { "solo": false }
+		},
+		{
+			"id": 156,
+			"userId": "688220820945895424",
+			"model": "Completion",
+			"recordId": "436",
+			"name": "Silence Madness||Fish",
+			"action": "update",
+			"timestamp": "2024-08-26T07:13:52.405Z",
+			"before": { "solo": false },
+			"after": { "solo": true }
+		},
+		{
+			"id": 157,
+			"userId": "688220820945895424",
+			"model": "User",
+			"recordId": "688220820945895424",
+			"name": "LuminoscityTim",
+			"action": "update",
+			"timestamp": "2024-08-26T07:24:57.032Z",
+			"before": { "permissions": [0, 1, 2, 3, 4, 5] },
+			"after": { "permissions": [0, 1, 2, 3, 4] }
+		},
+		{
+			"id": 158,
+			"userId": "688220820945895424",
+			"model": "User",
+			"recordId": "688220820945895424",
+			"name": "LuminoscityTim",
+			"action": "update",
+			"timestamp": "2024-08-26T12:18:12.706Z",
+			"before": { "permissions": [0, 1, 2, 3, 4] },
+			"after": { "permissions": [0, 1, 2, 3, 4, 5] }
+		}
+	],
+	"User": [
+		{
+			"id": "688220820945895424",
+			"username": "LuminoscityTim",
+			"discordName": "luminoscity",
+			"avatar": "1e3ac96d5e44e6439107935cfa2f2aa1",
+			"permissions": [0, 1, 2, 3, 4, 5]
+		}
+	]
+}

--- a/importer/import.js
+++ b/importer/import.js
@@ -127,7 +127,7 @@ const { PrismaClient } = pkg;
 	await client.$transaction(missionQueries);
 
 	let completionQueries = [];
-	for (const [index, completion] of completions.entries()) {
+	for (const [_, completion] of completions.entries()) {
 		const comp = await client.completion.findMany({
 			where: {
 				mission: {

--- a/importer/importAdvanced.js
+++ b/importer/importAdvanced.js
@@ -1,0 +1,62 @@
+import { readFileSync } from 'fs';
+import pkg from '@prisma/client';
+const { PrismaClient } = pkg;
+
+(async function () {
+	const client = new PrismaClient();
+
+	let data = JSON.parse(readFileSync('advanced.json').toString());
+	let logs = data.AuditLog;
+	let users = data.User;
+
+	let userQueries = [];
+	users.sort((a, b) => a.id.localeCompare(b.id));
+	for (const user of users) {
+		let userData = {
+			username: user.username,
+			discordName: user.discordName,
+			avatar: user.avatar,
+			permissions: user.permissions
+		};
+		userQueries.push(
+			client.user.upsert({
+				create: {
+					...userData,
+					id: user.id,
+					accessToken: '',
+					refreshToken: ''
+				},
+				update: userData,
+				where: {
+					id: user.id
+				}
+			})
+		);
+	}
+	await client.$transaction(userQueries);
+
+	let logQueries = [];
+	logs.sort((a, b) => parseInt(a.id) - parseInt(b.id));
+	for (const log of logs) {
+		const user = await client.user.findFirst({
+			where: { id: log.userId },
+			select: { id: true }
+		});
+		let logData = {
+			model: log.model,
+			recordId: log.recordId,
+			name: log.name,
+			action: log.action,
+			timestamp: log.timestamp,
+			before: log.before,
+			after: log.after
+		};
+		if (user) logData.userId = log.userId;
+		logQueries.push(
+			client.auditLog.create({
+				data: logData
+			})
+		);
+	}
+	await client.$transaction(logQueries);
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "ktane-bombs",
 			"version": "0.0.1",
 			"dependencies": {
-				"@prisma/client": "^3.13.0",
+				"@prisma/client": "^4.16.2",
 				"@sveltejs/adapter-auto": "^1.0.0-next.80",
 				"cookie": "^0.5.0",
 				"discord-oauth2": "^2.11.0",
@@ -26,7 +26,7 @@
 				"eslint-plugin-svelte3": "^4.0.0",
 				"prettier": "^2.5.1",
 				"prettier-plugin-svelte": "^2.5.0",
-				"prisma": "^3.15.2",
+				"prisma": "^4.16.2",
 				"svelte": "^3.44.0",
 				"svelte-check": "^2.2.6",
 				"svelte-preprocess": "^4.10.1",
@@ -199,14 +199,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@prisma/client": {
-			"version": "3.15.2",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.2.tgz",
+			"integrity": "sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==",
 			"hasInstallScript": true,
-			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/engines-version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+				"@prisma/engines-version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
 			},
 			"engines": {
-				"node": ">=12.6"
+				"node": ">=14.17"
 			},
 			"peerDependencies": {
 				"prisma": "*"
@@ -218,14 +219,16 @@
 			}
 		},
 		"node_modules/@prisma/engines": {
-			"version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.2.tgz",
+			"integrity": "sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==",
 			"devOptional": true,
-			"hasInstallScript": true,
-			"license": "Apache-2.0"
+			"hasInstallScript": true
 		},
 		"node_modules/@prisma/engines-version": {
-			"version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e",
-			"license": "Apache-2.0"
+			"version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
+			"integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg=="
 		},
 		"node_modules/@rollup/plugin-commonjs": {
 			"version": "23.0.7",
@@ -2311,20 +2314,20 @@
 			}
 		},
 		"node_modules/prisma": {
-			"version": "3.15.2",
-			"resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.2.tgz",
-			"integrity": "sha512-nMNSMZvtwrvoEQ/mui8L/aiCLZRCj5t6L3yujKpcDhIPk7garp8tL4nMx2+oYsN0FWBacevJhazfXAbV1kfBzA==",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.2.tgz",
+			"integrity": "sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@prisma/engines": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+				"@prisma/engines": "4.16.2"
 			},
 			"bin": {
 				"prisma": "build/index.js",
 				"prisma2": "build/index.js"
 			},
 			"engines": {
-				"node": ">=12.6"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/prisma-exclude": {
@@ -3213,17 +3216,23 @@
 			"dev": true
 		},
 		"@prisma/client": {
-			"version": "3.15.2",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.2.tgz",
+			"integrity": "sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==",
 			"requires": {
-				"@prisma/engines-version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+				"@prisma/engines-version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
 			}
 		},
 		"@prisma/engines": {
-			"version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.2.tgz",
+			"integrity": "sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==",
 			"devOptional": true
 		},
 		"@prisma/engines-version": {
-			"version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+			"version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
+			"integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg=="
 		},
 		"@rollup/plugin-commonjs": {
 			"version": "23.0.7",
@@ -4491,12 +4500,12 @@
 			"requires": {}
 		},
 		"prisma": {
-			"version": "3.15.2",
-			"resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.2.tgz",
-			"integrity": "sha512-nMNSMZvtwrvoEQ/mui8L/aiCLZRCj5t6L3yujKpcDhIPk7garp8tL4nMx2+oYsN0FWBacevJhazfXAbV1kfBzA==",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.2.tgz",
+			"integrity": "sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==",
 			"devOptional": true,
 			"requires": {
-				"@prisma/engines": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+				"@prisma/engines": "4.16.2"
 			}
 		},
 		"prisma-exclude": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"eslint-plugin-svelte3": "^4.0.0",
 		"prettier": "^2.5.1",
 		"prettier-plugin-svelte": "^2.5.0",
-		"prisma": "^3.15.2",
+		"prisma": "^4.16.2",
 		"svelte": "^3.44.0",
 		"svelte-check": "^2.2.6",
 		"svelte-preprocess": "^4.10.1",
@@ -31,7 +31,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@prisma/client": "^3.13.0",
+		"@prisma/client": "^4.16.2",
 		"@sveltejs/adapter-auto": "^1.0.0-next.80",
 		"cookie": "^0.5.0",
 		"discord-oauth2": "^2.11.0",

--- a/prisma/migrations/20240714124037_add_audit_log/migration.sql
+++ b/prisma/migrations/20240714124037_add_audit_log/migration.sql
@@ -5,6 +5,7 @@ CREATE TABLE "AuditLog" (
     "model" TEXT NOT NULL,
     "recordId" TEXT NOT NULL,
     "action" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
     "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "before" JSONB,
     "after" JSONB,

--- a/prisma/migrations/20240714124037_add_audit_log/migration.sql
+++ b/prisma/migrations/20240714124037_add_audit_log/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" SERIAL NOT NULL,
+    "userId" TEXT,
+    "model" TEXT NOT NULL,
+    "recordId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "before" JSONB,
+    "after" JSONB,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   accessToken  String
   refreshToken String
   permissions  Int[]
+  logs         AuditLog[]
 }
 
 model MissionPack {
@@ -79,4 +80,16 @@ model Completion {
   missionId Int
 
   verified Boolean @default(true)
+}
+
+model AuditLog {
+  id	Int @id @default(autoincrement())
+  userId String?
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+  model String
+  recordId String
+  action String
+  timestamp DateTime @default(now())
+  before Json?
+  after Json?
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,20 +76,21 @@ model Completion {
   dateAdded    DateTime?
   uploadedBy   String?
 
-  mission   Mission @relation(fields: [missionId], references: [id], onDelete: Cascade)
-  missionId Int
+  mission      Mission @relation(fields: [missionId], references: [id], onDelete: Cascade)
+  missionId    Int
 
-  verified Boolean @default(true)
+  verified     Boolean @default(true)
 }
 
 model AuditLog {
-  id	Int @id @default(autoincrement())
-  userId String?
-  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
-  model String
-  recordId String
-  action String
-  timestamp DateTime @default(now())
-  before Json?
-  after Json?
+  id	       Int @id @default(autoincrement())
+  userId     String?
+  user       User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+  model      String
+  recordId   String
+  name       String
+  action     String
+  timestamp  DateTime @default(now())
+  before     Json?
+  after      Json?
 }

--- a/src/lib/auditlog.ts
+++ b/src/lib/auditlog.ts
@@ -1,238 +1,237 @@
 import client from '$lib/client';
 import { FrontendUser } from '$lib/types';
 
-function diff(beforeObject: any, afterObject: any){
-	const before: {[id: string] : any} = {}
-	const after: {[id: string] : any} = {}
+function diff(beforeObject: any, afterObject: any) {
+	const before: { [id: string]: any } = {};
+	const after: { [id: string]: any } = {};
 	for (const key in afterObject) {
-		if (beforeObject[key] != afterObject[key]) {
-			before[key] = beforeObject[key]
-			after[key] = afterObject[key]
+		if (JSON.stringify(beforeObject[key]) != JSON.stringify(afterObject[key])) {
+			console.log(`key: ${key}`);
+			console.log(`before: ${beforeObject[key]}`);
+			console.log(`after: ${afterObject[key]}`);
+			before[key] = beforeObject[key];
+			after[key] = afterObject[key];
 		}
 	}
-	return [before, after]
+	console.log('');
+	return [before, after];
 }
 
-const auditTables: {[id: string] : any} = {
+const auditTables: { [id: string]: any } = {
 	Completion: client.completion,
 	Mission: client.mission,
 	MissionPack: client.missionPack,
 	User: client.user
+};
+
+function findName(record: any, model: string): string {
+	if (model === 'Completion')
+		return (
+			(record.mission ? record.mission.name : 'Unknown') + '||' + (record.team ? record.team.join(', ') : 'Unknown')
+		);
+	else if (model === 'User') return record.username ?? 'Unknown';
+	return record.name ?? 'Unknown';
 }
 
-const auditOperations: {[id: string] : any} = {
+const auditOperations: { [id: string]: any } = {
 	async update(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const record = await modelObject.findFirst({where: args.where})
+		const record = await modelObject.findFirst({ where: args.where });
 
-		const [before, after] = diff(record, args.data)
+		const [before, after] = diff(record, args.data);
+		let name = findName(record, model);
 
-		await client.auditLog.create(
-			{
+		if (Object.keys(before).length > 0 || Object.keys(after).length > 0)
+			await client.auditLog.create({
 				data: {
 					userId: user.id,
 					model: model,
 					recordId: record.id.toString(),
+					name: name,
 					action: 'update',
 					before: before,
 					after: after
 				}
-			}
-		)
+			});
 
-		return query(args)
+		return query(args);
 	},
 	async delete(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const record = await modelObject.findFirst({where: args.where})
+		const record = await modelObject.findFirst({ where: args.where });
+		let name = findName(record, model);
 
-		await client.auditLog.create(
-			{
+		await client.auditLog.create({
+			data: {
+				userId: user.id,
+				model: model,
+				recordId: record.id.toString(),
+				name: record.name,
+				action: 'delete',
+				before: record
+			}
+		});
+
+		return query(args);
+	},
+	async deleteMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const records = await modelObject.findMany({ where: args.where });
+
+		for (const record of records) {
+			let name = findName(record, model);
+			await client.auditLog.create({
 				data: {
 					userId: user.id,
 					model: model,
 					recordId: record.id.toString(),
+					name: record.name,
 					action: 'delete',
 					before: record
 				}
-			}
-		)
-
-		return query(args)
-	},
-	async deleteMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const records = await modelObject.findMany({where: args.where})
-
-		for (const record of records) {
-			
-			await client.auditLog.create(
-				{
-					data: {
-						userId: user.id,
-						model: model,
-						recordId: record.id.toString(),
-						action: 'delete',
-						before: record
-					}
-				}
-			)
+			});
 		}
 
-		return query(args)
+		return query(args);
 	},
 	async updateMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const records = await modelObject.findMany({where: args.where})
+		const records = await modelObject.findMany({ where: args.where });
 
 		for (const record of records) {
-			
-			const [before, after] = diff(record, args.data)
+			const [before, after] = diff(record, args.data);
+			let name = findName(record, model);
 
-			await client.auditLog.create(
-				{
+			if (Object.keys(before).length > 0 || Object.keys(after).length > 0)
+				await client.auditLog.create({
 					data: {
 						userId: user.id,
 						model: model,
 						recordId: record.id.toString(),
+						name: record.name,
 						action: 'update',
 						before: before,
 						after: after
 					}
-				}
-			)
+				});
 		}
 
-		return query(args)
+		return query(args);
 	},
 	async create(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const record = await query(args)
+		const record = await query(args);
+		let name = findName(record, model);
 
-		await client.auditLog.create(
-			{
+		await client.auditLog.create({
+			data: {
+				userId: user.id,
+				model: model,
+				recordId: record.id.toString(),
+				name: record.name,
+				action: 'create'
+				// after: record
+			}
+		});
+
+		return record;
+	},
+	async upsert(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await modelObject.findFirst({ where: args.where });
+		let name = findName(record, model);
+
+		if (record) {
+			//update
+			const [before, after] = diff(record, args.update);
+
+			if (Object.keys(before).length > 0 || Object.keys(after).length > 0)
+				await client.auditLog.create({
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						name: record.name,
+						action: 'update',
+						before: before,
+						after: after
+					}
+				});
+
+			return query(args);
+		} else {
+			//create
+
+			const record = await query(args);
+
+			await client.auditLog.create({
 				data: {
 					userId: user.id,
 					model: model,
 					recordId: record.id.toString(),
+					name: record.name,
 					action: 'create',
 					after: record
 				}
-			}
-		)
+			});
 
-		return record
-	},
-	async upsert(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
-		const record = await modelObject.findFirst({where: args.where})
-		
-		if (record) {
-			//update
-			const [before, after] = diff(record, args.update)
-
-			await client.auditLog.create(
-				{
-					data: {
-						userId: user.id,
-						model: model,
-						recordId: record.id.toString(),
-						action: 'update',
-						before: before,
-						after: after
-					}
-				}
-			)
-
-			
-			return query(args)
-		}
-		else {
-			//create
-
-			const record = await query(args)
-
-			await client.auditLog.create(
-				{
-					data: {
-						userId: user.id,
-						model: model,
-						recordId: record.id.toString(),
-						action: 'create',
-						after: record
-					}
-				}
-			)
-
-			return record
+			return record;
 		}
 	}
-}
+};
 
 function createAuditClient(user: FrontendUser | null) {
-	return client.$extends(
-		{
-			name: 'Audit Log',
-			query: {
-				$allModels: {
-					async $allOperations( { model, operation, args, query }) {
-						if (!user || !model) return query(args);
+	return client.$extends({
+		name: 'Audit Log',
+		query: {
+			$allModels: {
+				async $allOperations({ model, operation, args, query }) {
+					if (!user || !model) return query(args);
 
-						if (!auditTables[model] || !auditOperations[operation]) return query(args);
+					if (!auditTables[model] || !auditOperations[operation]) return query(args);
 
-						return await auditOperations[operation](user, auditTables[model], model, args, query)
-					}
+					return await auditOperations[operation](user, auditTables[model], model, args, query);
 				}
-			},
-			model: {
-				auditLog: {
-					async fromUser(userId: string) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									userId: userId
-								}
-							}
-						)
-					},
-					async forCompletion(completionId: number) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'Completion',
-									recordId: completionId.toString()
-								}
-							}
-						)
-					},
-					async forMission(missionId: number) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'Mission',
-									recordId: missionId.toString()
-								}
-							}
-						)
-					},
-					async forMissionPack(missionPackId: number) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'Missionpack',
-									recordId: missionPackId.toString()
-								}
-							}
-						)
-					},
-					async forUser(userId: string) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'User',
-									recordId: userId
-								}
-							}
-						)
-					}
+			}
+		},
+		model: {
+			auditLog: {
+				async fromUser(userId: string) {
+					return await client.auditLog.findMany({
+						where: {
+							userId: userId
+						}
+					});
+				},
+				async forCompletion(completionId: number) {
+					return await client.auditLog.findMany({
+						where: {
+							model: 'Completion',
+							recordId: completionId.toString()
+						}
+					});
+				},
+				async forMission(missionId: number) {
+					return await client.auditLog.findMany({
+						where: {
+							model: 'Mission',
+							recordId: missionId.toString()
+						}
+					});
+				},
+				async forMissionPack(missionPackId: number) {
+					return await client.auditLog.findMany({
+						where: {
+							model: 'Missionpack',
+							recordId: missionPackId.toString()
+						}
+					});
+				},
+				async forUser(userId: string) {
+					return await client.auditLog.findMany({
+						where: {
+							model: 'User',
+							recordId: userId
+						}
+					});
 				}
 			}
 		}
-	)
+	});
 }
 
-export default createAuditClient
+export default createAuditClient;

--- a/src/lib/auditlog.ts
+++ b/src/lib/auditlog.ts
@@ -163,7 +163,7 @@ const auditOperations: {[id: string] : any} = {
 	}
 }
 
-function auditClient(user: FrontendUser | null) {
+function createAuditClient(user: FrontendUser | null) {
 	return client.$extends(
 		{
 			name: 'Audit Log',
@@ -235,4 +235,4 @@ function auditClient(user: FrontendUser | null) {
 	)
 }
 
-export default auditClient
+export default createAuditClient

--- a/src/lib/auditlog.ts
+++ b/src/lib/auditlog.ts
@@ -1,0 +1,238 @@
+import client from '$lib/client';
+import { FrontendUser } from '$lib/types';
+
+function diff(beforeObject: any, afterObject: any){
+	const before: {[id: string] : any} = {}
+	const after: {[id: string] : any} = {}
+	for (const key in afterObject) {
+		if (beforeObject[key] != afterObject[key]) {
+			before[key] = beforeObject[key]
+			after[key] = afterObject[key]
+		}
+	}
+	return [before, after]
+}
+
+const auditTables: {[id: string] : any} = {
+	Completion: client.completion,
+	Mission: client.mission,
+	MissionPack: client.missionPack,
+	User: client.user
+}
+
+const auditOperations: {[id: string] : any} = {
+	async update(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await modelObject.findFirst({where: args.where})
+
+		const [before, after] = diff(record, args.data)
+
+		await client.auditLog.create(
+			{
+				data: {
+					userId: user.id,
+					model: model,
+					recordId: record.id.toString(),
+					action: 'update',
+					before: before,
+					after: after
+				}
+			}
+		)
+
+		return query(args)
+	},
+	async delete(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await modelObject.findFirst({where: args.where})
+
+		await client.auditLog.create(
+			{
+				data: {
+					userId: user.id,
+					model: model,
+					recordId: record.id.toString(),
+					action: 'delete',
+					before: record
+				}
+			}
+		)
+
+		return query(args)
+	},
+	async deleteMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const records = await modelObject.findMany({where: args.where})
+
+		for (const record of records) {
+			
+			await client.auditLog.create(
+				{
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						action: 'delete',
+						before: record
+					}
+				}
+			)
+		}
+
+		return query(args)
+	},
+	async updateMany(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const records = await modelObject.findMany({where: args.where})
+
+		for (const record of records) {
+			
+			const [before, after] = diff(record, args.data)
+
+			await client.auditLog.create(
+				{
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						action: 'update',
+						before: before,
+						after: after
+					}
+				}
+			)
+		}
+
+		return query(args)
+	},
+	async create(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await query(args)
+
+		await client.auditLog.create(
+			{
+				data: {
+					userId: user.id,
+					model: model,
+					recordId: record.id.toString(),
+					action: 'create',
+					after: record
+				}
+			}
+		)
+
+		return record
+	},
+	async upsert(user: FrontendUser, modelObject: any, model: string, args: any, query: any) {
+		const record = await modelObject.findFirst({where: args.where})
+		
+		if (record) {
+			//update
+			const [before, after] = diff(record, args.update)
+
+			await client.auditLog.create(
+				{
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						action: 'update',
+						before: before,
+						after: after
+					}
+				}
+			)
+
+			
+			return query(args)
+		}
+		else {
+			//create
+
+			const record = await query(args)
+
+			await client.auditLog.create(
+				{
+					data: {
+						userId: user.id,
+						model: model,
+						recordId: record.id.toString(),
+						action: 'create',
+						after: record
+					}
+				}
+			)
+
+			return record
+		}
+	}
+}
+
+function auditClient(user: FrontendUser | null) {
+	return client.$extends(
+		{
+			name: 'Audit Log',
+			query: {
+				$allModels: {
+					async $allOperations( { model, operation, args, query }) {
+						if (!user || !model) return query(args);
+
+						if (!auditTables[model] || !auditOperations[operation]) return query(args);
+
+						return await auditOperations[operation](user, auditTables[model], model, args, query)
+					}
+				}
+			},
+			model: {
+				auditLog: {
+					async fromUser(userId: string) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									userId: userId
+								}
+							}
+						)
+					},
+					async forBomb(bombId: number) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'bomb',
+									recordId: bombId.toString()
+								}
+							}
+						)
+					},
+					async forCompletion(completionId: number) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'completion',
+									recordId: completionId.toString()
+								}
+							}
+						)
+					},
+					async forMission(missionId: number) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'mission',
+									recordId: missionId.toString()
+								}
+							}
+						)
+					},
+					async forMissionPack(missionPackId: number) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'missionpack',
+									recordId: missionPackId.toString()
+								}
+							}
+						)
+					}
+				}
+			}
+		}
+	)
+}
+
+export default auditClient

--- a/src/lib/auditlog.ts
+++ b/src/lib/auditlog.ts
@@ -189,21 +189,11 @@ function auditClient(user: FrontendUser | null) {
 							}
 						)
 					},
-					async forBomb(bombId: number) {
-						return await client.auditLog.findMany(
-							{
-								where: {
-									model: 'bomb',
-									recordId: bombId.toString()
-								}
-							}
-						)
-					},
 					async forCompletion(completionId: number) {
 						return await client.auditLog.findMany(
 							{
 								where: {
-									model: 'completion',
+									model: 'Completion',
 									recordId: completionId.toString()
 								}
 							}
@@ -213,7 +203,7 @@ function auditClient(user: FrontendUser | null) {
 						return await client.auditLog.findMany(
 							{
 								where: {
-									model: 'mission',
+									model: 'Mission',
 									recordId: missionId.toString()
 								}
 							}
@@ -223,8 +213,18 @@ function auditClient(user: FrontendUser | null) {
 						return await client.auditLog.findMany(
 							{
 								where: {
-									model: 'missionpack',
+									model: 'Missionpack',
 									recordId: missionPackId.toString()
+								}
+							}
+						)
+					},
+					async forUser(userId: string) {
+						return await client.auditLog.findMany(
+							{
+								where: {
+									model: 'User',
+									recordId: userId
 								}
 							}
 						)

--- a/src/lib/comp/LayoutSearchFilter.svelte
+++ b/src/lib/comp/LayoutSearchFilter.svelte
@@ -18,6 +18,8 @@
 	export let numResults: number = 0;
 	export let showNoneForBlank: boolean = false;
 	export let searching: boolean = false;
+	export let showAll: boolean = true;
+	export let resultLimit: number = 50;
 
 	const dispatch = createEventDispatcher();
 	let searchField: HTMLInputElement | null;
@@ -41,7 +43,8 @@
 		Object.keys(items).forEach(item => {
 			if (showNoneForBlank && searchText.length == 0) items[item]?.classList.add('search-filtered-out');
 			else if (filterFunc(item, searchText)) {
-				items[item]?.classList.remove('search-filtered-out');
+				if (showAll || numResults < resultLimit) items[item]?.classList.remove('search-filtered-out');
+				else items[item]?.classList.add('search-filtered-out');
 				numResults++;
 			} else items[item]?.classList.add('search-filtered-out');
 		});

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,1 +1,2 @@
 export const TP_TEAM = 'Twitch Plays';
+export const UNKNOWN_ITEM = '[[Unknown]]';

--- a/src/lib/controls/Checkbox.svelte
+++ b/src/lib/controls/Checkbox.svelte
@@ -5,18 +5,19 @@
 	export let sideLabel: boolean = false;
 	export let labelAfter: boolean = false;
 	export let disabled: boolean = false;
+	export let title: string = '';
 </script>
 
 <div class:hstack={sideLabel}>
 	{#if !labelAfter}
-		<label for={id}>
+		<label {title} for={id}>
 			{label}
 			<slot />
 		</label>
 	{/if}
 	<input {id} type="checkbox" bind:checked {disabled} on:change />
 	{#if labelAfter}
-		<label for={id}>
+		<label {title} for={id}>
 			{label}
 			<slot />
 		</label>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -94,6 +94,7 @@
 		--needy-color: #9999ff;
 		--quirks-color: #aae8ff;
 		--stick-under-navbar: calc(1.25em + 4 * var(--gap) + 2px);
+		--page-content-width: min(calc(100vw - 4 * var(--gap)), 1150px);
 	}
 
 	@media (prefers-color-scheme: dark) {
@@ -317,7 +318,7 @@
 	}
 
 	.max-width {
-		width: min(calc(100vw - 4 * var(--gap)), 1150px);
+		width: var(--page-content-width);
 		margin: 0 auto;
 	}
 

--- a/src/routes/auditlog/+page.server.ts
+++ b/src/routes/auditlog/+page.server.ts
@@ -1,0 +1,49 @@
+import client from '$lib/client';
+import { Permission } from '$lib/types';
+import { forbidden, hasAnyPermission } from '$lib/util';
+
+export const load = async function ({ parent, locals }: any) {
+	const { user } = await parent();
+	if (!hasAnyPermission(user, Permission.VerifyMission, Permission.VerifyCompletion, Permission.VerifyMissionPack)) {
+		throw forbidden(locals);
+	}
+
+	const everything = await client.auditLog.findMany({
+		orderBy: { id: 'asc' }
+	});
+
+	let logs: any[] = [];
+	for (let i = 0; i < everything.length; i++) {
+		let log = {
+			...everything[i],
+			linkable: false,
+			mission: null
+		};
+		if (log.userId != null) {
+			const usr = await client.user.findUnique({
+				where: { id: log.userId },
+				select: { username: true }
+			});
+			if (usr !== null) {
+				log.userId = usr.username;
+			}
+		}
+		logs.push(log);
+	}
+
+	return {
+		logs,
+		fromUser: null,
+		editMissions: null,
+		newMissions: null,
+		deleteMissions: null,
+		editPacks: null,
+		newPacks: null,
+		deletePacks: null,
+		editCompletions: null,
+		newCompletions: null,
+		deleteCompletions: null,
+		editUsers: null,
+		deleteUsers: null
+	};
+};

--- a/src/routes/auditlog/+page.server.ts
+++ b/src/routes/auditlog/+page.server.ts
@@ -63,6 +63,20 @@ export const load = async function ({ parent, locals }: any) {
 			linkable: nameInfo.linkable,
 			mission: nameInfo.mission
 		};
+		if (log.before) {
+			let before = JSON.parse(JSON.stringify(log.before));
+			if (before && typeof before.uploadedBy === 'string') {
+				const usr = await client.user.findUnique({
+					where: { id: before.uploadedBy },
+					select: { username: true }
+				});
+				if (usr !== null) {
+					before.uploadedBy = usr.username;
+					log.before = JSON.parse(JSON.stringify(before));
+				}
+			}
+		}
+
 		if (log.userId != null) {
 			const usr = await client.user.findUnique({
 				where: { id: log.userId },

--- a/src/routes/auditlog/+page.server.ts
+++ b/src/routes/auditlog/+page.server.ts
@@ -51,7 +51,7 @@ export const load = async function ({ parent, locals }: any) {
 	}
 
 	const everything = await client.auditLog.findMany({
-		orderBy: { id: 'asc' }
+		orderBy: { id: 'desc' }
 	});
 
 	let logs: any[] = [];

--- a/src/routes/auditlog/+page.svelte
+++ b/src/routes/auditlog/+page.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	import { isOnlyDigits, properUrlEncode } from '$lib/util.js';
+	import { AuditLog, Prisma } from '@prisma/client';
+
+	const dateOptions: Intl.DateTimeFormatOptions = {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit'
+	};
+
+	export let data;
+	let logs: AuditLog[] = data.logs;
+
+	function pastTense(log: AuditLog): string {
+		if (log.model === 'Mission' && (log.action === 'delete' || log.action === 'update')) {
+			const missonStatsBef = JSON.parse(JSON.stringify(log.before));
+			const missonStatsAft = JSON.parse(JSON.stringify(log.after));
+			if (log.action === 'delete' && missonStatsBef.verified === false) return 'rejected';
+			else if (log.action === 'update' && missonStatsBef.verified === false && missonStatsAft.verified === true)
+				return 'accepted';
+		}
+		return log.action + (log.action.endsWith('e') ? 'd' : 'ed');
+	}
+	function shortName(str: string): string {
+		if (str.length > 24) return str.substring(0, 24) + ' ...';
+		else return str;
+	}
+	function displayLog(js: Prisma.JsonValue) {
+		const str = JSON.stringify(js, undefined, 1);
+		const stats = JSON.parse(str);
+		if (stats == null || stats == undefined || Object.keys(stats).length == 0) return { short: '', full: '' };
+		return { short: str.substring(0, 250), full: str };
+	}
+
+	function reveal(before: boolean, index: number) {
+		let elem = document.querySelector(`.dropdown.${before ? 'before' : 'after'}${index}`);
+		elem?.classList.add('expand');
+	}
+	function hide(before: boolean, index: number) {
+		let elem = document.querySelector(`.dropdown.${before ? 'before' : 'after'}${index}`);
+		elem?.classList.remove('expand');
+	}
+	function closeAll() {
+		document.querySelectorAll('.dropdown:not(.small)').forEach(el => {
+			el.classList.remove('expand');
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>Audit Log</title>
+</svelte:head>
+<h1 class="header">Audit Log</h1>
+<div class="block">
+	<button on:click={closeAll}>Close All</button>
+</div>
+
+<div class="table">
+	<div class="block" />
+	<b class="block">Description</b>
+	<b class="block">Before</b>
+	<b class="block">After</b>
+	{#each logs as log, index}
+		<div class="block number">{index + 1}</div>
+		<div class="block">
+			{#if log.userId != null && !isOnlyDigits(log.userId)}
+				<a href="/user/{properUrlEncode(log.userId)}">{log.userId}</a>
+			{:else}
+				{log.userId}
+			{/if}
+			<br />
+			{pastTense(log)}
+			{log.model.toLowerCase()} <br />
+			{#if log.model === 'Mission'}
+				<a href="/mission/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+			{:else if log.model === 'Missionpack'}
+				<a href="/missionpack/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+			{:else if log.model === 'Completion'}
+				{@const names = log.name.split('||')}
+				{names[1]} on <br />
+				<a href="/mission/{properUrlEncode(names[0])}">{shortName(names[0])}</a>
+			{:else if log.model === 'User'}
+				<a href="/user/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+			{/if}
+			<br />
+			{log.timestamp.toLocaleDateString(undefined, dateOptions)}
+		</div>
+		{@const before = displayLog(log.before)}
+		<div
+			class="block dropdown before{index}"
+			class:small={before.full.length < 250}
+			class:expand={before.full.length < 250}>
+			<div class="short" on:click={() => reveal(true, index)}>
+				{before.short} <strong>...</strong>
+			</div>
+			<div class="full">
+				<div class="contract" on:click={() => hide(true, index)} />
+				{before.full}
+			</div>
+		</div>
+		{@const after = displayLog(log.after)}
+		<div
+			class="block dropdown after{index}"
+			class:small={after.full.length < 250}
+			class:expand={after.full.length < 250}>
+			<div class="short" on:click={() => reveal(false, index)}>
+				{after.short} <strong>...</strong>
+			</div>
+			<div class="full">
+				<div class="contract" on:click={() => hide(false, index)} />
+				{after.full}
+			</div>
+		</div>
+	{/each}
+</div>
+
+<style>
+	:root {
+		--cell-width: calc((var(--page-content-width) - 240px) / 2 - var(--gap));
+	}
+	.number {
+		font-size: 10px;
+		padding: 1px;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+	.table {
+		display: grid;
+		grid-template-columns: 30px 210px var(--cell-width) var(--cell-width);
+		gap: var(--gap);
+		text-align: center;
+		width: 100%;
+		overflow: hidden;
+	}
+	.table > div {
+		overflow-wrap: break-word;
+	}
+	.dropdown:not(.expand) {
+		cursor: pointer;
+	}
+	.dropdown:not(.expand) div.full,
+	.dropdown.expand div.short {
+		display: none;
+	}
+	.dropdown.small .contract {
+		display: none;
+	}
+	.contract {
+		background: url('$lib/img/clear-button.svg') right center no-repeat;
+		width: 1.25em;
+		height: 1.25em;
+		min-width: 1.25em;
+		display: inline-block;
+		vertical-align: middle;
+		cursor: pointer;
+	}
+</style>

--- a/src/routes/auditlog/+page.svelte
+++ b/src/routes/auditlog/+page.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
+	import LayoutSearchFilter from '$lib/comp/LayoutSearchFilter.svelte';
 	import { UNKNOWN_ITEM } from '$lib/const.js';
-	import { isOnlyDigits, onlyUnique, properUrlEncode } from '$lib/util.js';
+	import Checkbox from '$lib/controls/Checkbox.svelte';
+	import {
+		evaluateLogicalStringSearch,
+		isOnlyDigits,
+		logicalSearchTooltip,
+		onlyUnique,
+		properUrlEncode,
+		titleCase
+	} from '$lib/util.js';
 	import { AuditLog, Prisma } from '@prisma/client';
+	import { onMount } from 'svelte';
 
 	const dateOptions: Intl.DateTimeFormatOptions = {
 		year: 'numeric',
@@ -13,6 +23,24 @@
 
 	export let data;
 	let logs: (AuditLog & { linkable: boolean; mission: string | null })[] = data.logs;
+
+	let logRows: any = {};
+	let resultsText: number = logs.length;
+	let searchOptionBoxes = ['from user', 'mission', 'mission pack', 'solve', 'user', 'invert'];
+	let searchOptionTooltips = [
+		'Search for the user that made the change',
+		'Search for mission name',
+		'Search for mission pack name',
+		'Search for solve team or mission name for a solve',
+		'Search for edited users',
+		'Invert search'
+	];
+	let layoutSearch: LayoutSearchFilter;
+	let searchOptions: string[] = [];
+	let showAll = false;
+	const resultLimit = 50;
+	let validSearchOptions: boolean[] = Array(searchOptionBoxes.length).fill(false);
+	validSearchOptions[1] = validSearchOptions[2] = validSearchOptions[3] = true;
 
 	function pastTense(log: AuditLog): string {
 		if (
@@ -89,84 +117,177 @@
 			el.classList.remove('expand');
 		});
 	}
+
+	function logSearchFilter(name: string, searchText: string): boolean {
+		let text = searchText.toLowerCase();
+		let searchWhat: string[] = [];
+		let log = logs[parseInt(name)];
+		let model = log.model.toLocaleLowerCase();
+
+		if (
+			(searchOptions?.includes('mission') && model === 'mission') ||
+			(searchOptions?.includes('mission pack') && model === 'missionpack') ||
+			(searchOptions?.includes('user') && model === 'user')
+		) {
+			searchWhat.push(log.name.toLowerCase());
+		}
+		if (searchOptions?.includes('solve') && model === 'completion') {
+			searchWhat.push(log.name.toLowerCase());
+			if (log.mission) searchWhat.push(log.mission.toLowerCase());
+		}
+		if (searchOptions?.includes('from user')) {
+			if (log.userId) searchWhat.push(log.userId.toLowerCase());
+		}
+
+		let textMatch = evaluateLogicalStringSearch(text, searchWhat);
+
+		let optionMatch =
+			searchOptions.includes('from user') ||
+			searchOptions.includes(model) ||
+			(searchOptions.includes('solve') && model == 'completion') ||
+			(searchOptions.includes('mission pack') && model == 'missionpack');
+
+		return searchOptions.includes('invert') != (optionMatch && textMatch);
+	}
+	function setSearchOptions() {
+		let options = searchOptionBoxes.filter((_, idx) => {
+			return validSearchOptions[idx];
+		});
+		searchOptions = options;
+		searchOptionBoxes.forEach((o, i) => {
+			validSearchOptions[i] = options.includes(o);
+		});
+		layoutSearch.updateSearch();
+	}
+	onMount(() => {
+		setSearchOptions();
+	});
 </script>
 
 <svelte:head>
 	<title>Audit Log</title>
 </svelte:head>
 <h1 class="header">Audit Log</h1>
-<div class="block">
-	<button on:click={closeAll}>Close All</button>
+
+<div class="top-bar block">
+	<div class="hstack">
+		<span>Max {resultLimit} results shown</span>
+		<Checkbox
+			id="show-all-check"
+			on:change={() => {
+				layoutSearch.updateSearch();
+			}}
+			bind:checked={showAll}
+			label="Show All"
+			sideLabel
+			labelAfter />
+	</div>
+	<div class="flex row search-bar">
+		<span>Results: {resultsText} of {logs.length}</span>
+		<LayoutSearchFilter
+			id="log-search-field"
+			label="Search:"
+			rows={1}
+			textArea
+			autoExpand
+			title={logicalSearchTooltip}
+			bind:items={logRows}
+			bind:numResults={resultsText}
+			bind:this={layoutSearch}
+			filterFunc={logSearchFilter}
+			bind:showAll
+			{resultLimit}
+			classes="help" />
+		<button on:click={closeAll}>Close All</button>
+		{#each searchOptionBoxes as option, index}
+			<Checkbox
+				id="search-by-{option.replace(/ /g, '')}"
+				label={titleCase(option)}
+				sideLabel
+				labelAfter
+				title={searchOptionTooltips[index]}
+				on:change={setSearchOptions}
+				bind:checked={validSearchOptions[index]} />
+		{/each}
+		<!-- <span class="sort-option alphabetical" class:selected={sortOption == 'alphabetical'} on:click={alphabetical}
+		>Alphabetical</span>
+	<span class="sort-option popular" class:selected={sortOption == 'popular'} on:click={popular}>Popular</span>
+	<span class="sort-option published" class:selected={sortOption == 'published'} on:click={published}>Published</span> -->
+	</div>
 </div>
 
 <div class="table">
-	<div class="block" />
-	<b class="block">Description</b>
-	<div class="block table-headers">
-		<b>Item</b>
-		<b>Before</b>
-		<b>After</b>
+	<div class="table-row">
+		<div class="block" />
+		<b class="block">Description</b>
+		<div class="block table-headers">
+			<b>Item</b>
+			<b>Before</b>
+			<b>After</b>
+		</div>
 	</div>
 	{#each logs as log, index}
-		<div class="block number">{logs.length - index}</div>
-		<div class="block">
-			{#if log.userId != null && !isOnlyDigits(log.userId)}
-				<a href="/user/{properUrlEncode(log.userId)}">{log.userId}</a>
-			{:else}
-				{log.userId}
-			{/if}
-			<br />
-			{pastTense(log)}
-			{log.model.toLowerCase()} <br />
-			{#if log.model === 'Mission'}
-				{#if log.linkable}
-					<a href="/mission/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
-				{:else}
-					{unlinkable(log.name)}
-				{/if}
-			{:else if log.model === 'MissionPack'}
-				{#if log.linkable}
-					<a href="/missionpack/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
-				{:else}
-					{unlinkable(log.name)}
-				{/if}
-			{:else if log.model === 'Completion'}
-				<span title={log.name}>{shortTeam(log.name)}</span> on <br />
-				{#if log.linkable && log.mission != null}
-					<a href="/mission/{properUrlEncode(log.mission)}">{shortName(log.mission)}</a>
-				{:else}
-					{unlinkable(log.name)}
-				{/if}
-			{:else if log.model === 'User'}
-				{#if log.linkable}
-					<a href="/user/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
-				{:else}
-					{unlinkable(log.name)}
-				{/if}
-			{/if}
-			<br />
-			{log.timestamp.toLocaleDateString(undefined, dateOptions)}
-		</div>
 		{@const display = displayLog(log.before, log.after)}
-		<div class="block dropdown d{index}" class:small={smallItem(display.full)} class:expand={smallItem(display.full)}>
-			<div class="short" on:click={() => reveal(index)}>
-				<div class="log-details">
-					{#each display.short as row}
-						<div title={row.item}>{shortItem(row.item)}</div>
-						<div>{row.before}</div>
-						<div>{row.after}</div>
-					{/each}
-				</div>
-				<strong>...</strong>
+		<div class="table-row" bind:this={logRows[index]}>
+			<div class="block number">{logs.length - index}</div>
+			<div class="block">
+				{#if log.userId != null && !isOnlyDigits(log.userId)}
+					<a href="/user/{properUrlEncode(log.userId)}">{log.userId}</a>
+				{:else}
+					{log.userId}
+				{/if}
+				<br />
+				{pastTense(log)}
+				{log.model.toLowerCase()} <br />
+				{#if log.model === 'Mission'}
+					{#if log.linkable}
+						<a href="/mission/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+					{:else}
+						{unlinkable(log.name)}
+					{/if}
+				{:else if log.model === 'MissionPack'}
+					{#if log.linkable}
+						<a href="/missionpack/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+					{:else}
+						{unlinkable(log.name)}
+					{/if}
+				{:else if log.model === 'Completion'}
+					<span title={log.name}>{shortTeam(log.name)}</span> on <br />
+					{#if log.linkable && log.mission != null}
+						<a href="/mission/{properUrlEncode(log.mission)}">{shortName(log.mission)}</a>
+					{:else}
+						{unlinkable(log.name)}
+					{/if}
+				{:else if log.model === 'User'}
+					{#if log.linkable}
+						<a href="/user/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+					{:else}
+						{unlinkable(log.name)}
+					{/if}
+				{/if}
+				<br />
+				{log.timestamp.toLocaleDateString(undefined, dateOptions)}
 			</div>
-			<div class="full">
-				<div class="contract" on:click={() => hide(index)} />
-				<div class="log-details">
-					{#each display.full as row}
-						<div title={row.item}>{shortItem(row.item)}</div>
-						<div>{row.before}</div>
-						<div>{row.after}</div>
-					{/each}
+			<div class="block dropdown d{index}" class:small={smallItem(display.full)} class:expand={smallItem(display.full)}>
+				<div class="short" on:click={() => reveal(index)}>
+					<div class="log-details">
+						{#each display.short as row}
+							<div title={row.item}>{shortItem(row.item)}</div>
+							<div>{row.before}</div>
+							<div>{row.after}</div>
+						{/each}
+					</div>
+					<strong>...</strong>
+				</div>
+				<div class="full">
+					<div class="contract" on:click={() => hide(index)} />
+					<div class="log-details">
+						{#each display.full as row}
+							<div title={row.item}>{shortItem(row.item)}</div>
+							<div>{row.before}</div>
+							<div>{row.after}</div>
+						{/each}
+					</div>
 				</div>
 			</div>
 		</div>
@@ -177,6 +298,22 @@
 	:root {
 		--cell-width: calc((var(--page-content-width) - 240px) / 2 - var(--gap) - 120px);
 	}
+
+	.top-bar {
+		position: sticky;
+		top: calc(var(--stick-under-navbar) + 1px);
+	}
+	.search-bar {
+		gap: 12px;
+		align-items: center;
+		flex-wrap: wrap;
+		margin-top: var(--gap);
+	}
+	.hstack {
+		display: flex;
+		gap: 8px;
+	}
+
 	.number {
 		font-size: 10px;
 		padding: 1px;
@@ -192,15 +329,16 @@
 	.table-headers b {
 		text-align: left;
 	}
-	.table {
+	.table-row {
 		display: grid;
 		grid-template-columns: 30px 210px auto;
 		gap: var(--gap);
 		text-align: center;
 		width: 100%;
 		overflow: hidden;
+		margin: var(--gap) auto;
 	}
-	.table > div {
+	.table-row > div {
 		overflow-wrap: break-word;
 	}
 	.dropdown:not(.expand) {

--- a/src/routes/auditlog/+page.svelte
+++ b/src/routes/auditlog/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { isOnlyDigits, properUrlEncode } from '$lib/util.js';
+	import { UNKNOWN_ITEM } from '$lib/const.js';
+	import { isOnlyDigits, onlyUnique, properUrlEncode } from '$lib/util.js';
 	import { AuditLog, Prisma } from '@prisma/client';
 
 	const dateOptions: Intl.DateTimeFormatOptions = {
@@ -11,35 +12,76 @@
 	};
 
 	export let data;
-	let logs: AuditLog[] = data.logs;
+	let logs: (AuditLog & { linkable: boolean; mission: string | null })[] = data.logs;
 
 	function pastTense(log: AuditLog): string {
-		if (log.model === 'Mission' && (log.action === 'delete' || log.action === 'update')) {
-			const missonStatsBef = JSON.parse(JSON.stringify(log.before));
-			const missonStatsAft = JSON.parse(JSON.stringify(log.after));
-			if (log.action === 'delete' && missonStatsBef.verified === false) return 'rejected';
-			else if (log.action === 'update' && missonStatsBef.verified === false && missonStatsAft.verified === true)
-				return 'accepted';
+		if (
+			(log.model === 'Mission' || log.model === 'MissionPack' || log.model === 'Completion') &&
+			(log.action === 'delete' || log.action === 'update')
+		) {
+			const statsBef = JSON.parse(JSON.stringify(log.before));
+			const statsAft = JSON.parse(JSON.stringify(log.after));
+			if (log.action === 'delete' && statsBef.verified === false) return 'rejected';
+			else if (log.action === 'update' && statsBef.verified === false && statsAft.verified === true) return 'accepted';
 		}
 		return log.action + (log.action.endsWith('e') ? 'd' : 'ed');
 	}
 	function shortName(str: string): string {
-		if (str.length > 24) return str.substring(0, 24) + ' ...';
+		if (str.length > 24) return str.substring(0, 22) + ' ...';
 		else return str;
 	}
-	function displayLog(js: Prisma.JsonValue) {
-		const str = JSON.stringify(js, undefined, 1);
-		const stats = JSON.parse(str);
-		if (stats == null || stats == undefined || Object.keys(stats).length == 0) return { short: '', full: '' };
-		return { short: str.substring(0, 250), full: str };
+	function unlinkable(str: string): string {
+		if (str === UNKNOWN_ITEM) return 'Unknown';
+		return shortName(str);
+	}
+	function shortTeam(str: string): string {
+		if (str.length > 23) return str.substring(0, 21) + '...';
+		else return str;
+	}
+	function shortItem(str: string): string {
+		if (str.length > 13) return str.substring(0, 11) + '...';
+		else return str;
 	}
 
-	function reveal(before: boolean, index: number) {
-		let elem = document.querySelector(`.dropdown.${before ? 'before' : 'after'}${index}`);
+	type ItemDetails = { item: string; before: string; after: string };
+	const CELL_LIM = 100;
+	function smallItem(item: ItemDetails[]) {
+		return item.length < 4 && item.every(itm => itm.before.length < CELL_LIM && itm.after.length < CELL_LIM);
+	}
+	function displayLog(before: Prisma.JsonValue, after: Prisma.JsonValue) {
+		let beforeStr = JSON.stringify(before); //before, undefined, 1);
+		let beforeStats = JSON.parse(beforeStr);
+		let beforeKeys = Object.keys(beforeStats ?? {});
+		let afterStr = JSON.stringify(after);
+		let afterStats = JSON.parse(afterStr);
+		let afterKeys = Object.keys(afterStats ?? {});
+		let keys = [...beforeKeys, ...afterKeys].filter(onlyUnique);
+		keys.sort();
+		let table = [];
+		for (const key in keys) {
+			let row: ItemDetails = { item: keys[key], before: '', after: '' };
+			if (beforeStats != null && keys[key] in beforeStats) row.before = JSON.stringify(beforeStats[keys[key]]);
+			if (afterStats != null && keys[key] in afterStats) row.after = JSON.stringify(afterStats[keys[key]]);
+			table.push(row);
+		}
+
+		// if (stats == null || stats == undefined || Object.keys(stats).length == 0) return { short: '', full: '' };
+		return {
+			short: table.slice(0, 3).map(row => ({
+				item: row.item,
+				before: row.before.substring(0, CELL_LIM),
+				after: row.after.substring(0, CELL_LIM)
+			})),
+			full: table
+		};
+	}
+
+	function reveal(index: number) {
+		let elem = document.querySelector(`.dropdown.d${index}`);
 		elem?.classList.add('expand');
 	}
-	function hide(before: boolean, index: number) {
-		let elem = document.querySelector(`.dropdown.${before ? 'before' : 'after'}${index}`);
+	function hide(index: number) {
+		let elem = document.querySelector(`.dropdown.d${index}`);
 		elem?.classList.remove('expand');
 	}
 	function closeAll() {
@@ -60,8 +102,11 @@
 <div class="table">
 	<div class="block" />
 	<b class="block">Description</b>
-	<b class="block">Before</b>
-	<b class="block">After</b>
+	<div class="block table-headers">
+		<b>Item</b>
+		<b>Before</b>
+		<b>After</b>
+	</div>
 	{#each logs as log, index}
 		<div class="block number">{index + 1}</div>
 		<div class="block">
@@ -74,43 +119,55 @@
 			{pastTense(log)}
 			{log.model.toLowerCase()} <br />
 			{#if log.model === 'Mission'}
-				<a href="/mission/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
-			{:else if log.model === 'Missionpack'}
-				<a href="/missionpack/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+				{#if log.linkable}
+					<a href="/mission/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+				{:else}
+					{unlinkable(log.name)}
+				{/if}
+			{:else if log.model === 'MissionPack'}
+				{#if log.linkable}
+					<a href="/missionpack/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+				{:else}
+					{unlinkable(log.name)}
+				{/if}
 			{:else if log.model === 'Completion'}
-				{@const names = log.name.split('||')}
-				{names[1]} on <br />
-				<a href="/mission/{properUrlEncode(names[0])}">{shortName(names[0])}</a>
+				<span title={log.name}>{shortTeam(log.name)}</span> on <br />
+				{#if log.linkable && log.mission != null}
+					<a href="/mission/{properUrlEncode(log.mission)}">{shortName(log.mission)}</a>
+				{:else}
+					{unlinkable(log.name)}
+				{/if}
 			{:else if log.model === 'User'}
-				<a href="/user/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+				{#if log.linkable}
+					<a href="/user/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+				{:else}
+					{unlinkable(log.name)}
+				{/if}
 			{/if}
 			<br />
 			{log.timestamp.toLocaleDateString(undefined, dateOptions)}
 		</div>
-		{@const before = displayLog(log.before)}
-		<div
-			class="block dropdown before{index}"
-			class:small={before.full.length < 250}
-			class:expand={before.full.length < 250}>
-			<div class="short" on:click={() => reveal(true, index)}>
-				{before.short} <strong>...</strong>
+		{@const display = displayLog(log.before, log.after)}
+		<div class="block dropdown d{index}" class:small={smallItem(display.full)} class:expand={smallItem(display.full)}>
+			<div class="short" on:click={() => reveal(index)}>
+				<div class="log-details">
+					{#each display.short as row}
+						<div title={row.item}>{shortItem(row.item)}</div>
+						<div>{row.before}</div>
+						<div>{row.after}</div>
+					{/each}
+				</div>
+				<strong>...</strong>
 			</div>
 			<div class="full">
-				<div class="contract" on:click={() => hide(true, index)} />
-				{before.full}
-			</div>
-		</div>
-		{@const after = displayLog(log.after)}
-		<div
-			class="block dropdown after{index}"
-			class:small={after.full.length < 250}
-			class:expand={after.full.length < 250}>
-			<div class="short" on:click={() => reveal(false, index)}>
-				{after.short} <strong>...</strong>
-			</div>
-			<div class="full">
-				<div class="contract" on:click={() => hide(false, index)} />
-				{after.full}
+				<div class="contract" on:click={() => hide(index)} />
+				<div class="log-details">
+					{#each display.full as row}
+						<div title={row.item}>{shortItem(row.item)}</div>
+						<div>{row.before}</div>
+						<div>{row.after}</div>
+					{/each}
+				</div>
 			</div>
 		</div>
 	{/each}
@@ -118,7 +175,7 @@
 
 <style>
 	:root {
-		--cell-width: calc((var(--page-content-width) - 240px) / 2 - var(--gap));
+		--cell-width: calc((var(--page-content-width) - 240px) / 2 - var(--gap) - 120px);
 	}
 	.number {
 		font-size: 10px;
@@ -127,9 +184,17 @@
 		flex-direction: column;
 		justify-content: center;
 	}
+	.table-headers,
+	.log-details {
+		display: grid;
+		grid-template-columns: 120px var(--cell-width) var(--cell-width);
+	}
+	.table-headers b {
+		text-align: left;
+	}
 	.table {
 		display: grid;
-		grid-template-columns: 30px 210px var(--cell-width) var(--cell-width);
+		grid-template-columns: 30px 210px auto;
 		gap: var(--gap);
 		text-align: center;
 		width: 100%;
@@ -145,8 +210,16 @@
 	.dropdown.expand div.short {
 		display: none;
 	}
+	.dropdown div.full {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
 	.dropdown.small .contract {
 		display: none;
+	}
+	.dropdown .log-details div {
+		text-align: left;
 	}
 	.contract {
 		background: url('$lib/img/clear-button.svg') right center no-repeat;

--- a/src/routes/auditlog/+page.svelte
+++ b/src/routes/auditlog/+page.svelte
@@ -108,7 +108,7 @@
 		<b>After</b>
 	</div>
 	{#each logs as log, index}
-		<div class="block number">{index + 1}</div>
+		<div class="block number">{logs.length - index}</div>
 		<div class="block">
 			{#if log.userId != null && !isOnlyDigits(log.userId)}
 				<a href="/user/{properUrlEncode(log.userId)}">{log.userId}</a>

--- a/src/routes/auditlog/+page.svelte
+++ b/src/routes/auditlog/+page.svelte
@@ -54,21 +54,8 @@
 		}
 		return log.action + (log.action.endsWith('e') ? 'd' : 'ed');
 	}
-	function shortName(str: string): string {
-		if (str.length > 24) return str.substring(0, 22) + ' ...';
-		else return str;
-	}
 	function unlinkable(str: string): string {
-		if (str === UNKNOWN_ITEM) return 'Unknown';
-		return shortName(str);
-	}
-	function shortTeam(str: string): string {
-		if (str.length > 23) return str.substring(0, 21) + '...';
-		else return str;
-	}
-	function shortItem(str: string): string {
-		if (str.length > 13) return str.substring(0, 11) + '...';
-		else return str;
+		return str === UNKNOWN_ITEM ? 'Unknown' : str;
 	}
 
 	type ItemDetails = { item: string; before: string; after: string };
@@ -241,28 +228,28 @@
 				{log.model.toLowerCase()} <br />
 				{#if log.model === 'Mission'}
 					{#if log.linkable}
-						<a href="/mission/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+						<a title={log.name} class="shorten" href="/mission/{properUrlEncode(log.name)}">{log.name}</a>
 					{:else}
-						{unlinkable(log.name)}
+						<span title={unlinkable(log.name)} class="shorten">{unlinkable(log.name)}</span>
 					{/if}
 				{:else if log.model === 'MissionPack'}
 					{#if log.linkable}
-						<a href="/missionpack/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+						<a title={log.name} class="shorten" href="/missionpack/{properUrlEncode(log.name)}">{log.name}</a>
 					{:else}
-						{unlinkable(log.name)}
+						<span title={unlinkable(log.name)} class="shorten">{unlinkable(log.name)}</span>
 					{/if}
 				{:else if log.model === 'Completion'}
-					<span title={log.name}>{shortTeam(log.name)}</span> on <br />
+					<span title={log.name} class="shorten">{log.name}</span> <span class="shorten">on</span> <br />
 					{#if log.linkable && log.mission != null}
-						<a href="/mission/{properUrlEncode(log.mission)}">{shortName(log.mission)}</a>
+						<a title={log.mission} class="shorten" href="/mission/{properUrlEncode(log.mission)}">{log.mission}</a>
 					{:else}
-						{unlinkable(log.name)}
+						<span title={unlinkable(log.name)} class="shorten">{unlinkable(log.name)}</span>
 					{/if}
 				{:else if log.model === 'User'}
 					{#if log.linkable}
-						<a href="/user/{properUrlEncode(log.name)}">{shortName(log.name)}</a>
+						<a title={log.name} class="shorten" href="/user/{properUrlEncode(log.name)}">{log.name}</a>
 					{:else}
-						{unlinkable(log.name)}
+						<span title={unlinkable(log.name)} class="shorten">{unlinkable(log.name)}</span>
 					{/if}
 				{/if}
 				<br />
@@ -272,7 +259,7 @@
 				<div class="short" on:click={() => reveal(index)}>
 					<div class="log-details">
 						{#each display.short as row}
-							<div title={row.item}>{shortItem(row.item)}</div>
+							<div title={row.item} class="shorten-detail">{row.item}</div>
 							<div>{row.before}</div>
 							<div>{row.after}</div>
 						{/each}
@@ -283,7 +270,7 @@
 					<div class="contract" on:click={() => hide(index)} />
 					<div class="log-details">
 						{#each display.full as row}
-							<div title={row.item}>{shortItem(row.item)}</div>
+							<div title={row.item} class="shorten-detail">{row.item}</div>
 							<div>{row.before}</div>
 							<div>{row.after}</div>
 						{/each}
@@ -312,6 +299,20 @@
 	.hstack {
 		display: flex;
 		gap: 8px;
+	}
+
+	.shorten {
+		max-width: 200px;
+	}
+	.shorten-detail {
+		max-width: 115px;
+	}
+	.shorten,
+	.shorten-detail {
+		display: inline-block;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.number {

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -5,7 +5,7 @@
 	<h1 class="header">What’s New?</h1>
 </div>
 <div class="block update">
-	<h3>29 August 2024</h3>
+	<h3>4 September 2024</h3>
 	<ul>
 		<li>Twitch Plays can no longer claim "Top Times" on a user page.</li>
 		<li><a href="/modules">Modules</a> page now limits the number of results by default.</li>

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -8,6 +8,7 @@
 	<h3>29 August 2024</h3>
 	<ul>
 		<li>Twitch Plays can no longer claim "Top Times" on a user page.</li>
+		<li><a href="/modules">Modules</a> page now limits the number of results by default.</li>
 		<li>A few backend updates for maintainers.</li>
 	</ul>
 </div>

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -5,6 +5,13 @@
 	<h1 class="header">What’s New?</h1>
 </div>
 <div class="block update">
+	<h3>29 August 2024</h3>
+	<ul>
+		<li>Twitch Plays can no longer claim "Top Times" on a user page.</li>
+		<li>A few backend updates for maintainers.</li>
+	</ul>
+</div>
+<div class="block update">
 	<h3>10 June 2024</h3>
 	<ul>
 		<li>

--- a/src/routes/json/separatedata/+server.ts
+++ b/src/routes/json/separatedata/+server.ts
@@ -1,0 +1,43 @@
+import client from '$lib/client';
+import { Bomb, Permission } from '$lib/types';
+import { dateAddedSort, forbidden, hasPermission } from '$lib/util';
+import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
+import { minimize } from '../_util';
+import { AuditLog, User } from '@prisma/client';
+
+export const GET: RequestHandler = async function ({ locals }: RequestEvent) {
+	if (!hasPermission(locals.user, Permission.DownloadDatabase)) {
+		throw forbidden(locals);
+	}
+	const logResults = await client.auditLog.findMany({
+		orderBy: { id: 'asc' }
+	});
+
+	const userResults = await client.user.findMany({
+		orderBy: { id: 'asc' },
+		select: {
+			id: true,
+			username: true,
+			discordName: true,
+			avatar: true,
+			permissions: true
+		}
+	});
+
+	let logs: { AuditLog: AuditLog[]; User: User[] } = {
+		AuditLog: [],
+		User: []
+	};
+	logResults.forEach(log => {
+		let newLog = JSON.parse(JSON.stringify(log));
+		minimize(newLog);
+		logs.AuditLog.push(newLog);
+	});
+	userResults.forEach(log => {
+		let newUser = JSON.parse(JSON.stringify(log));
+		minimize(newUser);
+		logs.User.push(newUser);
+	});
+
+	return new Response(JSON.stringify(logs));
+};

--- a/src/routes/login-callback/+page.server.ts
+++ b/src/routes/login-callback/+page.server.ts
@@ -1,6 +1,6 @@
 import client from '$lib/client';
 import OAuth, { scope } from '$lib/oauth';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/index.js';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import type { Cookies } from '@sveltejs/kit';
 import type { TokenRequestResult } from 'discord-oauth2';
 import { redirect, error } from '@sveltejs/kit';

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { getData } from '$lib/repo';
 import { Completion, Permission, type ID } from '$lib/types';
 import { excludeArticleSort, forbidden, hasPermission, properUrlEncode } from '$lib/util';
@@ -96,10 +97,13 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.VerifyMission)) {
 			throw forbidden(locals);
 		}
+
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const mission = JSON.parse(fData.get('mission')?.toString() ?? '');
 
-		await client.mission.delete({
+		await userClient.mission.delete({
 			where: {
 				name: mission.name
 			}
@@ -111,10 +115,13 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.VerifyCompletion)) {
 			throw forbidden(locals);
 		}
+
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const completion: ID<Completion> = JSON.parse(fData.get('completion')?.toString() ?? '');
 
-		await client.completion.delete({
+		await userClient.completion.delete({
 			where: {
 				id: completion.id
 			}
@@ -126,6 +133,8 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.VerifyMission)) {
 			throw forbidden(locals);
 		}
+
+		const userClient = auditClient(locals.user)
 
 		const fData = await request.formData();
 		const mission: EditMission = JSON.parse(fData.get('mission')?.toString() ?? '');
@@ -158,7 +167,7 @@ export const actions: Actions = {
 				});
 				//if there is only one other, remove that one's variant ID too since you need at least 2 missions in a variant group
 				if (other.length == 1) {
-					await client.mission.update({
+					await userClient.mission.update({
 						where: {
 							id: other[0].id
 						},
@@ -187,7 +196,7 @@ export const actions: Actions = {
 					});
 					let max = Math.max(...variants.map(v => v.variant ?? -1));
 					mission.variant = max + 1;
-					await client.mission.update({
+					await userClient.mission.update({
 						where: {
 							id: selected.id
 						},
@@ -199,7 +208,7 @@ export const actions: Actions = {
 			}
 		}
 
-		await client.mission.update({
+		await userClient.mission.update({
 			where: {
 				id: mission.id
 			},
@@ -254,7 +263,9 @@ export async function POST({ locals, request }: RequestEvent) {
 
 	const mission: EditMission = await request.json();
 
-	await client.mission.update({
+	const userClient = auditClient(locals.user)
+
+	await userClient.mission.update({
 		where: {
 			id: mission.id
 		},
@@ -284,7 +295,9 @@ export async function DELETE({ locals, request }: RequestEvent) {
 
 	const completion: ID<Completion> = await request.json();
 
-	await client.completion.delete({
+	const userClient = auditClient(locals.user)
+
+	await userClient.completion.delete({
 		where: {
 			id: completion.id
 		}

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -130,6 +130,34 @@ export const actions: Actions = {
 
 		return {};
 	},
+	editCompletion: async ({ locals, request }: RequestEvent) => {
+		if (!hasPermission(locals.user, Permission.VerifyCompletion)) {
+			throw forbidden(locals);
+		}
+
+		const auditClient = createAuditClient(locals.user);
+
+		const fData = await request.formData();
+		const completion: ID<Completion> = JSON.parse(fData.get('completion')?.toString() ?? '');
+
+		await auditClient.completion.update({
+			where: {
+				id: completion.id
+			},
+			data: {
+				proofs: completion.proofs,
+				time: completion.time,
+				solo: completion.solo,
+				first: completion.first,
+				old: completion.old,
+				team: completion.team,
+				notes: completion.notes,
+				dateAdded: completion.dateAdded
+			}
+		});
+
+		return {};
+	},
 	editMission: async ({ locals, request }: RequestEvent) => {
 		if (!hasPermission(locals.user, Permission.VerifyMission)) {
 			throw forbidden(locals);
@@ -245,27 +273,6 @@ export const actions: Actions = {
 									widgets: bomb.widgets,
 									pools: JSON.parse(JSON.stringify(bomb.pools))
 								}
-							}))
-						}
-					}
-				});
-			}
-
-			//completions
-			beforeMission.completions.sort((a, b) => a.team.join('').localeCompare(b.team.join('')));
-			mission.completions.sort((a, b) => a.team.join('').localeCompare(b.team.join('')));
-			if (JSON.stringify(beforeMission.completions) != JSON.stringify(mission.completions)) {
-				await auditClient.mission.update({
-					where: {
-						id: mission.id
-					},
-					data: {
-						completions: {
-							update: mission.completions.map(completion => ({
-								where: {
-									id: completion.id
-								},
-								data: completion
 							}))
 						}
 					}

--- a/src/routes/mission/[mission]/edit/+page.server.ts
+++ b/src/routes/mission/[mission]/edit/+page.server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { getData } from '$lib/repo';
 import { Completion, Permission, type ID } from '$lib/types';
 import { excludeArticleSort, forbidden, hasPermission, properUrlEncode } from '$lib/util';
@@ -98,12 +98,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const mission = JSON.parse(fData.get('mission')?.toString() ?? '');
 
-		await userClient.mission.delete({
+		await auditClient.mission.delete({
 			where: {
 				name: mission.name
 			}
@@ -116,12 +116,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const completion: ID<Completion> = JSON.parse(fData.get('completion')?.toString() ?? '');
 
-		await userClient.completion.delete({
+		await auditClient.completion.delete({
 			where: {
 				id: completion.id
 			}
@@ -134,7 +134,7 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const mission: EditMission = JSON.parse(fData.get('mission')?.toString() ?? '');
@@ -167,7 +167,7 @@ export const actions: Actions = {
 				});
 				//if there is only one other, remove that one's variant ID too since you need at least 2 missions in a variant group
 				if (other.length == 1) {
-					await userClient.mission.update({
+					await auditClient.mission.update({
 						where: {
 							id: other[0].id
 						},
@@ -196,7 +196,7 @@ export const actions: Actions = {
 					});
 					let max = Math.max(...variants.map(v => v.variant ?? -1));
 					mission.variant = max + 1;
-					await userClient.mission.update({
+					await auditClient.mission.update({
 						where: {
 							id: selected.id
 						},
@@ -208,7 +208,7 @@ export const actions: Actions = {
 			}
 		}
 
-		await userClient.mission.update({
+		await auditClient.mission.update({
 			where: {
 				id: mission.id
 			},
@@ -263,9 +263,9 @@ export async function POST({ locals, request }: RequestEvent) {
 
 	const mission: EditMission = await request.json();
 
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
-	await userClient.mission.update({
+	await auditClient.mission.update({
 		where: {
 			id: mission.id
 		},
@@ -295,9 +295,9 @@ export async function DELETE({ locals, request }: RequestEvent) {
 
 	const completion: ID<Completion> = await request.json();
 
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
-	await userClient.completion.delete({
+	await auditClient.completion.delete({
 		where: {
 			id: completion.id
 		}

--- a/src/routes/missionpack/[missionpack]/edit/+page.server.ts
+++ b/src/routes/missionpack/[missionpack]/edit/+page.server.ts
@@ -56,7 +56,7 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const auditClient = createAuditClient(locals.user)
+		const auditClient = createAuditClient(locals.user);
 
 		const fData = await request.formData();
 		const pack = JSON.parse(fData.get('pack')?.toString() ?? '');
@@ -75,7 +75,7 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const auditClient = createAuditClient(locals.user)
+		const auditClient = createAuditClient(locals.user);
 
 		const fData = await request.formData();
 		const pack: EditMissionPack = JSON.parse(fData.get('pack')?.toString() ?? '');

--- a/src/routes/missionpack/[missionpack]/edit/+page.server.ts
+++ b/src/routes/missionpack/[missionpack]/edit/+page.server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import type { RequestEvent, ServerLoadEvent } from '@sveltejs/kit';
@@ -56,12 +56,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const pack = JSON.parse(fData.get('pack')?.toString() ?? '');
 
-		await userClient.missionPack.delete({
+		await auditClient.missionPack.delete({
 			where: {
 				name: pack.name
 			}
@@ -75,12 +75,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const pack: EditMissionPack = JSON.parse(fData.get('pack')?.toString() ?? '');
 
-		await userClient.missionPack.update({
+		await auditClient.missionPack.update({
 			where: {
 				id: pack.id
 			},

--- a/src/routes/missionpack/[missionpack]/edit/+page.server.ts
+++ b/src/routes/missionpack/[missionpack]/edit/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import type { RequestEvent, ServerLoadEvent } from '@sveltejs/kit';
@@ -54,10 +55,13 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.VerifyMissionPack)) {
 			throw forbidden(locals);
 		}
+
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const pack = JSON.parse(fData.get('pack')?.toString() ?? '');
 
-		await client.missionPack.delete({
+		await userClient.missionPack.delete({
 			where: {
 				name: pack.name
 			}
@@ -71,10 +75,12 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const pack: EditMissionPack = JSON.parse(fData.get('pack')?.toString() ?? '');
 
-		await client.missionPack.update({
+		await userClient.missionPack.update({
 			where: {
 				id: pack.id
 			},

--- a/src/routes/modules/+page.svelte
+++ b/src/routes/modules/+page.svelte
@@ -60,7 +60,7 @@
 		sortOption = 'published';
 		updateSearch();
 	}
-	function closeeAll() {
+	function closeAll() {
 		document.querySelectorAll('.missions-dropdown:not(.few)').forEach(el => {
 			el.classList.remove('expand');
 		});
@@ -109,7 +109,7 @@
 			bind:this={layoutSearch}
 			filterFunc={moduleSearchFilter}
 			classes="help" />
-		<button on:click={closeeAll}>Close All</button>
+		<button on:click={closeAll}>Close All</button>
 		<span class="sort-option alphabetical" class:selected={sortOption == 'alphabetical'} on:click={alphabetical}
 			>Alphabetical</span>
 		<span class="sort-option popular" class:selected={sortOption == 'popular'} on:click={popular}>Popular</span>

--- a/src/routes/upload/completion/+server.ts
+++ b/src/routes/upload/completion/+server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import type { Completion } from '$lib/types';
 import { forbidden } from '$lib/util';
 import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 	
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
 	const { completion, missionName }: { completion: Completion; missionName: string } = await request.json();
 	completion.uploadedBy = locals.user.id;
@@ -44,7 +44,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		//don't allow duplicate solve uploads that are already in the verify queue
 		return new Response(undefined, { status: 409 });
 
-	await userClient.completion.create({
+	await auditClient.completion.create({
 		data: {
 			...completion,
 			mission: {

--- a/src/routes/upload/completion/+server.ts
+++ b/src/routes/upload/completion/+server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import type { Completion } from '$lib/types';
 import { forbidden } from '$lib/util';
 import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
@@ -7,6 +8,9 @@ export async function POST({ locals, request }: RequestEvent) {
 	if (locals.user == null) {
 		throw forbidden(locals);
 	}
+	
+	const userClient = auditClient(locals.user)
+
 	const { completion, missionName }: { completion: Completion; missionName: string } = await request.json();
 	completion.uploadedBy = locals.user.id;
 	if (completion.team.length != 1 && completion.solo) {
@@ -40,7 +44,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		//don't allow duplicate solve uploads that are already in the verify queue
 		return new Response(undefined, { status: 409 });
 
-	await client.completion.create({
+	await userClient.completion.create({
 		data: {
 			...completion,
 			mission: {

--- a/src/routes/upload/completion/+server.ts
+++ b/src/routes/upload/completion/+server.ts
@@ -8,8 +8,8 @@ export async function POST({ locals, request }: RequestEvent) {
 	if (locals.user == null) {
 		throw forbidden(locals);
 	}
-	
-	const auditClient = createAuditClient(locals.user)
+
+	const auditClient = createAuditClient(locals.user);
 
 	const { completion, missionName }: { completion: Completion; missionName: string } = await request.json();
 	completion.uploadedBy = locals.user.id;

--- a/src/routes/upload/missionpack/+server.ts
+++ b/src/routes/upload/missionpack/+server.ts
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 
-	const auditClient = createAuditClient(locals.user)
+	const auditClient = createAuditClient(locals.user);
 
 	const pack: MissionPack = await request.json();
 	pack.uploadedBy = locals.user.id;

--- a/src/routes/upload/missionpack/+server.ts
+++ b/src/routes/upload/missionpack/+server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import type { MissionPack } from '$lib/types';
 import { forbidden } from '$lib/util';
 import type { RequestEvent } from '@sveltejs/kit';
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
 	const pack: MissionPack = await request.json();
 	pack.uploadedBy = locals.user.id;
@@ -27,7 +27,7 @@ export async function POST({ locals, request }: RequestEvent) {
 			return new Response('Mission pack is already in the queue for verfication.', { status: 409 });
 		else return new Response('Duplicate mission pack not uploaded.', { status: 406 });
 	}
-	await userClient.missionPack.create({
+	await auditClient.missionPack.create({
 		data: {
 			...pack,
 			verified: false

--- a/src/routes/upload/missionpack/+server.ts
+++ b/src/routes/upload/missionpack/+server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import type { MissionPack } from '$lib/types';
 import { forbidden } from '$lib/util';
 import type { RequestEvent } from '@sveltejs/kit';
@@ -7,6 +8,9 @@ export async function POST({ locals, request }: RequestEvent) {
 	if (locals.user == null) {
 		throw forbidden(locals);
 	}
+
+	const userClient = auditClient(locals.user)
+
 	const pack: MissionPack = await request.json();
 	pack.uploadedBy = locals.user.id;
 	let equalPack = await client.missionPack.findUnique({
@@ -23,7 +27,7 @@ export async function POST({ locals, request }: RequestEvent) {
 			return new Response('Mission pack is already in the queue for verfication.', { status: 409 });
 		else return new Response('Duplicate mission pack not uploaded.', { status: 406 });
 	}
-	await client.missionPack.create({
+	await userClient.missionPack.create({
 		data: {
 			...pack,
 			verified: false

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client'
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { error, type RequestEvent } from '@sveltejs/kit';
 import type { ReplaceableMission } from '../_types';
 import { forbidden } from '$lib/util';
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
 	const missions: ReplaceableMission[] = await request.json();
 	if (missions.some(m => m.missionPack === null)) {
@@ -37,7 +37,7 @@ export async function POST({ locals, request }: RequestEvent) {
 			if (!context.includes('R')) context += 'R';
 		} else if (!context.includes('N')) context += 'N';
 
-		await userClient.mission.create({
+		await auditClient.mission.create({
 			data: {
 				name: missionName,
 				authors: mission.authors,

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -1,4 +1,5 @@
-import client from '$lib/client';
+import client from '$lib/client'
+import auditClient from '$lib/auditlog';
 import { error, type RequestEvent } from '@sveltejs/kit';
 import type { ReplaceableMission } from '../_types';
 import { forbidden } from '$lib/util';
@@ -7,6 +8,9 @@ export async function POST({ locals, request }: RequestEvent) {
 	if (locals.user == null) {
 		throw forbidden(locals);
 	}
+
+	const userClient = auditClient(locals.user)
+
 	const missions: ReplaceableMission[] = await request.json();
 	if (missions.some(m => m.missionPack === null)) {
 		throw error(400, 'Mission pack is required.');
@@ -33,7 +37,7 @@ export async function POST({ locals, request }: RequestEvent) {
 			if (!context.includes('R')) context += 'R';
 		} else if (!context.includes('N')) context += 'N';
 
-		await client.mission.create({
+		await userClient.mission.create({
 			data: {
 				name: missionName,
 				authors: mission.authors,

--- a/src/routes/upload/missions/+server.ts
+++ b/src/routes/upload/missions/+server.ts
@@ -1,4 +1,4 @@
-import client from '$lib/client'
+import client from '$lib/client';
 import createAuditClient from '$lib/auditlog';
 import { error, type RequestEvent } from '@sveltejs/kit';
 import type { ReplaceableMission } from '../_types';
@@ -9,7 +9,7 @@ export async function POST({ locals, request }: RequestEvent) {
 		throw forbidden(locals);
 	}
 
-	const auditClient = createAuditClient(locals.user)
+	const auditClient = createAuditClient(locals.user);
 
 	const missions: ReplaceableMission[] = await request.json();
 	if (missions.some(m => m.missionPack === null)) {

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -210,8 +210,8 @@ export const actions = {
 		if (!hasPermission(locals.user, Permission.ModifyPermissions)) {
 			return forbidden(locals);
 		}
-		
-		const auditClient = createAuditClient(locals.user)
+
+		const auditClient = createAuditClient(locals.user);
 
 		const fData = await request.formData();
 		const body: Permission[] = JSON.parse(fData.get('perms')?.toString() ?? '');

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { TP_TEAM } from '$lib/const';
 import { Permission } from '$lib/types';
 import { fixPools, forbidden, hasPermission } from '$lib/util';
@@ -209,13 +210,16 @@ export const actions = {
 		if (!hasPermission(locals.user, Permission.ModifyPermissions)) {
 			return forbidden(locals);
 		}
+		
+		const userClient = auditClient(locals.user)
+
 		const fData = await request.formData();
 		const body: Permission[] = JSON.parse(fData.get('perms')?.toString() ?? '');
 		const user = fData.get('user')?.toString();
 		if (user === null || user === undefined) {
 			throw error(400);
 		}
-		await client.user.update({
+		await userClient.user.update({
 			where: {
 				id: user
 			},

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { TP_TEAM } from '$lib/const';
 import { Permission } from '$lib/types';
 import { fixPools, forbidden, hasPermission } from '$lib/util';
@@ -211,7 +211,7 @@ export const actions = {
 			return forbidden(locals);
 		}
 		
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const body: Permission[] = JSON.parse(fData.get('perms')?.toString() ?? '');
@@ -219,7 +219,7 @@ export const actions = {
 		if (user === null || user === undefined) {
 			throw error(400);
 		}
-		await userClient.user.update({
+		await auditClient.user.update({
 			where: {
 				id: user
 			},

--- a/src/routes/user/[user]/+page.server.ts
+++ b/src/routes/user/[user]/+page.server.ts
@@ -60,7 +60,10 @@ export const load = async function ({ parent, params }: any) {
 					}
 				},
 				where: {
-					verified: true
+					verified: true,
+					NOT: {
+						team: { has: TP_TEAM }
+					}
 				},
 				orderBy: { time: 'desc' },
 				take: 1

--- a/src/routes/user/rename/+server.ts
+++ b/src/routes/user/rename/+server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import type { RequestHandler } from '@sveltejs/kit';
@@ -8,7 +8,7 @@ import { redirect } from '@sveltejs/kit';
 export const POST: RequestHandler = async function ({ locals, request }) {
 	if (!hasPermission(locals.user, Permission.RenameUser)) forbidden(locals);
 	
-	const userClient = auditClient(locals.user)
+	const auditClient = createAuditClient(locals.user)
 
 	const { oldUsername, username, nameExistsOK } = await request.json();
 
@@ -82,7 +82,7 @@ export const POST: RequestHandler = async function ({ locals, request }) {
 
 	if (user !== null && user !== undefined) {
 		// User
-		await userClient.user.update({
+		await auditClient.user.update({
 			where: {
 				username: oldUsername
 			},

--- a/src/routes/user/rename/+server.ts
+++ b/src/routes/user/rename/+server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import type { RequestHandler } from '@sveltejs/kit';
@@ -6,6 +7,8 @@ import { redirect } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async function ({ locals, request }) {
 	if (!hasPermission(locals.user, Permission.RenameUser)) forbidden(locals);
+	
+	const userClient = auditClient(locals.user)
 
 	const { oldUsername, username, nameExistsOK } = await request.json();
 
@@ -79,7 +82,7 @@ export const POST: RequestHandler = async function ({ locals, request }) {
 
 	if (user !== null && user !== undefined) {
 		// User
-		await client.user.update({
+		await userClient.user.update({
 			where: {
 				username: oldUsername
 			},

--- a/src/routes/user/rename/+server.ts
+++ b/src/routes/user/rename/+server.ts
@@ -7,8 +7,8 @@ import { redirect } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async function ({ locals, request }) {
 	if (!hasPermission(locals.user, Permission.RenameUser)) forbidden(locals);
-	
-	const auditClient = createAuditClient(locals.user)
+
+	const auditClient = createAuditClient(locals.user);
 
 	const { oldUsername, username, nameExistsOK } = await request.json();
 

--- a/src/routes/users/rename/+page.server.ts
+++ b/src/routes/users/rename/+page.server.ts
@@ -30,8 +30,8 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.RenameUser)) {
 			throw forbidden(locals);
 		}
-		
-		const auditClient = createAuditClient(locals.user)
+
+		const auditClient = createAuditClient(locals.user);
 
 		const fData = await request.formData();
 		const oldUsername: string = JSON.parse(fData.get('oldUsername')?.toString() ?? '');

--- a/src/routes/users/rename/+page.server.ts
+++ b/src/routes/users/rename/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/client';
+import auditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import { redirect, type RequestEvent } from '@sveltejs/kit';
@@ -29,6 +30,8 @@ export const actions: Actions = {
 		if (!hasPermission(locals.user, Permission.RenameUser)) {
 			throw forbidden(locals);
 		}
+		
+		const userClient = auditClient(locals.user)
 
 		const fData = await request.formData();
 		const oldUsername: string = JSON.parse(fData.get('oldUsername')?.toString() ?? '');
@@ -42,7 +45,7 @@ export const actions: Actions = {
 
 		if (user !== null && user !== undefined) {
 			// User
-			await client.user.update({
+			await userClient.user.update({
 				where: {
 					username: oldUsername
 				},

--- a/src/routes/users/rename/+page.server.ts
+++ b/src/routes/users/rename/+page.server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/client';
-import auditClient from '$lib/auditlog';
+import createAuditClient from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import { forbidden, hasPermission, properUrlEncode } from '$lib/util';
 import { redirect, type RequestEvent } from '@sveltejs/kit';
@@ -31,7 +31,7 @@ export const actions: Actions = {
 			throw forbidden(locals);
 		}
 		
-		const userClient = auditClient(locals.user)
+		const auditClient = createAuditClient(locals.user)
 
 		const fData = await request.formData();
 		const oldUsername: string = JSON.parse(fData.get('oldUsername')?.toString() ?? '');
@@ -45,7 +45,7 @@ export const actions: Actions = {
 
 		if (user !== null && user !== undefined) {
 			// User
-			await userClient.user.update({
+			await auditClient.user.update({
 				where: {
 					username: oldUsername
 				},

--- a/src/routes/verify/+page.svelte
+++ b/src/routes/verify/+page.svelte
@@ -61,7 +61,10 @@
 	<title>Verify Queue</title>
 </svelte:head>
 
-<h1 class="header">Verify Queue</h1>
+<div class="block top-bar">
+	<a class="audit-log" href="/auditlog">Audit Log</a>
+	<h1 class="header">Verify Queue</h1>
+</div>
 
 <div class="flex column">
 	{#each queue as item, index (item)}
@@ -111,5 +114,14 @@
 	}
 	:is(span, .block).red {
 		color: red;
+	}
+
+	.top-bar {
+		position: relative;
+	}
+	.audit-log {
+		position: absolute;
+		top: var(--gap);
+		left: var(--gap);
 	}
 </style>

--- a/src/routes/verify/item/+server.ts
+++ b/src/routes/verify/item/+server.ts
@@ -8,7 +8,7 @@ import { TP_TEAM } from '$lib/const';
 export const POST: RequestHandler = async function ({ locals, request }: RequestEvent) {
 	const { accept, item, replaceId }: { accept: boolean; item: QueueItem; replaceId: number } = await request.json();
 
-	const client = asUser(locals.user)
+	const client = asUser(locals.user);
 	switch (item.type) {
 		case 'mission':
 			if (!hasPermission(locals.user, Permission.VerifyMission)) {

--- a/src/routes/verify/item/+server.ts
+++ b/src/routes/verify/item/+server.ts
@@ -1,14 +1,14 @@
-import asUser from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import type { QueueItem } from '$lib/types';
 import { forbidden, hasPermission } from '$lib/util';
 import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
 import { TP_TEAM } from '$lib/const';
+import createAuditClient from '$lib/auditlog';
 
 export const POST: RequestHandler = async function ({ locals, request }: RequestEvent) {
 	const { accept, item, replaceId }: { accept: boolean; item: QueueItem; replaceId: number } = await request.json();
 
-	const client = asUser(locals.user);
+	const client = createAuditClient(locals.user);
 	switch (item.type) {
 		case 'mission':
 			if (!hasPermission(locals.user, Permission.VerifyMission)) {

--- a/src/routes/verify/item/+server.ts
+++ b/src/routes/verify/item/+server.ts
@@ -1,4 +1,4 @@
-import client from '$lib/client';
+import asUser from '$lib/auditlog';
 import { Permission } from '$lib/types';
 import type { QueueItem } from '$lib/types';
 import { forbidden, hasPermission } from '$lib/util';
@@ -7,6 +7,8 @@ import { TP_TEAM } from '$lib/const';
 
 export const POST: RequestHandler = async function ({ locals, request }: RequestEvent) {
 	const { accept, item, replaceId }: { accept: boolean; item: QueueItem; replaceId: number } = await request.json();
+
+	const client = asUser(locals.user)
 	switch (item.type) {
 		case 'mission':
 			if (!hasPermission(locals.user, Permission.VerifyMission)) {


### PR DESCRIPTION
1. add AuditLog migration to database
2. add /auditlog page, link in the Verify tab. Must have one of the verify permissions to access the Audit Log page.
![image](https://github.com/user-attachments/assets/84b5e3c0-5893-4e9c-934a-9faab8dd941a)
![image](https://github.com/user-attachments/assets/9fd1856c-b080-432b-b4a5-2089a800624e)
![image](https://github.com/user-attachments/assets/ba3bf65b-7bdc-4bff-92a0-e0a35f476e73)

3. add endpoint for downloading the auditlog data (for devs to keep their local database up to date)
![image](https://github.com/user-attachments/assets/50d65e69-16d1-40e9-85ce-b8c3838b44fb)

4. Change the way the mission edit page handles solves. Now you can edit only a solve and not submit all the mission data all at once. You now press the Save button under the completion you just edited instead of the save button at the bottom of the page. This is convenient for editing solves, but was also quite necessary for the audit log to not be a complete mess when editing the solves of a mission.
![image](https://github.com/user-attachments/assets/698a93c7-0d61-405a-a882-97b2f3d6a5bc)

5. Add "Show All" checkbox to modules page (same on Audit Log page) that limits the number of results shown to 50 when unchecked.
![image](https://github.com/user-attachments/assets/aa0dc027-b3a9-401c-ac02-e458293bd6c6)

6. TP can no longer claim the "Top Times"
![image](https://github.com/user-attachments/assets/94429f60-f6b4-4d6c-8e25-f4fd9b639ee8)
