### PR TITLE
Fix inGameId parsing

### DIFF
--- a/importer/advanced.json
+++ b/importer/advanced.json
@@ -19845,6 +19845,1077 @@
 			"timestamp": "2024-12-04T08:25:15.236Z",
 			"before": { "verified": false },
 			"after": { "verified": true }
+		},
+		{
+			"id": 1308,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10824",
+			"name": "Devil's Advocate",
+			"action": "create",
+			"timestamp": "2024-12-05T19:14:26.792Z"
+		},
+		{
+			"id": 1309,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10825",
+			"name": "Timespread Tribulations",
+			"action": "create",
+			"timestamp": "2024-12-05T19:15:28.179Z"
+		},
+		{
+			"id": 1310,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10826",
+			"name": "Burger King Is Not Real",
+			"action": "create",
+			"timestamp": "2024-12-05T20:03:49.905Z"
+		},
+		{
+			"id": 1311,
+			"userId": "121400102148505600",
+			"model": "Completion",
+			"recordId": "60829",
+			"name": "Hummingbird||Skyeward, Rexkix, SillyPuppy",
+			"action": "create",
+			"timestamp": "2024-12-06T00:38:49.419Z"
+		},
+		{
+			"id": 1312,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60829",
+			"name": "Hummingbird||Skyeward, Rexkix, SillyPuppy",
+			"action": "update",
+			"timestamp": "2024-12-06T07:56:47.235Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1313,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60830",
+			"name": "Dependency||BladePL",
+			"action": "create",
+			"timestamp": "2024-12-06T14:20:29.358Z"
+		},
+		{
+			"id": 1314,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60831",
+			"name": "Arithmophobia||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-06T22:02:02.305Z"
+		},
+		{
+			"id": 1315,
+			"userId": "294221057311899649",
+			"model": "Completion",
+			"recordId": "60832",
+			"name": "By Popular Demand||GreenPower",
+			"action": "create",
+			"timestamp": "2024-12-07T06:11:07.755Z"
+		},
+		{
+			"id": 1316,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10777",
+			"name": "Simplest Challenge",
+			"action": "delete",
+			"timestamp": "2024-12-07T09:21:43.963Z",
+			"before": {
+				"id": 10777,
+				"name": "Simplest Challenge",
+				"notes": null,
+				"authors": ["boom shaka laka"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=422c65eb52e735521219abc09ab64ca22ba4cb62",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_tylerverifieseverything_Simplest Challenge",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-10-15T15:18:11.543Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "732019628615663698",
+				"designedForTP": false,
+				"missionPackId": 610
+			}
+		},
+		{
+			"id": 1317,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10801",
+			"name": "InDiscrete Topology",
+			"action": "update",
+			"timestamp": "2024-12-07T09:21:46.910Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1318,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10802",
+			"name": "Brauthem",
+			"action": "update",
+			"timestamp": "2024-12-07T09:21:47.793Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1319,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10803",
+			"name": "Jesús",
+			"action": "update",
+			"timestamp": "2024-12-07T09:21:48.400Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1320,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10804",
+			"name": "Alejandro",
+			"action": "update",
+			"timestamp": "2024-12-07T09:21:49.128Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1321,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10805",
+			"name": "Carlos",
+			"action": "update",
+			"timestamp": "2024-12-07T09:21:49.965Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1322,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10806",
+			"name": "The Biscuit",
+			"action": "update",
+			"timestamp": "2024-12-07T09:21:52.478Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1323,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10809",
+			"name": "Hotel Hell",
+			"action": "update",
+			"timestamp": "2024-12-07T09:21:59.456Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1324,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10810",
+			"name": "https://blananas2.github.io/random.html",
+			"action": "update",
+			"timestamp": "2024-12-07T09:22:00.378Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1325,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10811",
+			"name": "Not a Bomb",
+			"action": "update",
+			"timestamp": "2024-12-07T09:22:01.489Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1326,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60833",
+			"name": "Grammaphobia||Kugel",
+			"action": "create",
+			"timestamp": "2024-12-07T10:17:27.226Z"
+		},
+		{
+			"id": 1327,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10539",
+			"name": "Semipseudoquirky",
+			"action": "update",
+			"timestamp": "2024-12-07T12:27:09.292Z",
+			"before": { "notes": null },
+			"after": { "notes": "Updated version pending review. Solves temporarily frozen." }
+		},
+		{
+			"id": 1328,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10431",
+			"name": "Cyanturion",
+			"action": "update",
+			"timestamp": "2024-12-07T12:27:28.754Z",
+			"before": { "notes": null },
+			"after": { "notes": "Updated version pending review. Solves temporarily frozen." }
+		},
+		{
+			"id": 1329,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10432",
+			"name": "Random Chance Cyanturion",
+			"action": "update",
+			"timestamp": "2024-12-07T12:27:39.307Z",
+			"before": { "notes": null },
+			"after": { "notes": "Updated version pending review. Solves temporarily frozen." }
+		},
+		{
+			"id": 1330,
+			"userId": "483182665776889856",
+			"model": "Completion",
+			"recordId": "60834",
+			"name": "Decimator||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-07T12:59:14.723Z"
+		},
+		{
+			"id": 1331,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60830",
+			"name": "Dependency||BladePL",
+			"action": "update",
+			"timestamp": "2024-12-07T14:08:03.780Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1332,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10008",
+			"name": "Arithmophobia",
+			"action": "update",
+			"timestamp": "2024-12-07T14:09:42.179Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1333,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60831",
+			"name": "Arithmophobia||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-07T14:09:42.192Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1334,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60832",
+			"name": "By Popular Demand||GreenPower",
+			"action": "update",
+			"timestamp": "2024-12-07T14:11:13.960Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1335,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60833",
+			"name": "Grammaphobia||Kugel",
+			"action": "update",
+			"timestamp": "2024-12-07T14:14:05.534Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1336,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "9445",
+			"name": "Decimator",
+			"action": "update",
+			"timestamp": "2024-12-07T14:14:50.120Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1337,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60834",
+			"name": "Decimator||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-07T14:14:50.131Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1338,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60835",
+			"name": "Arithmophobia||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-07T16:43:37.984Z"
+		},
+		{
+			"id": 1339,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60836",
+			"name": "Decimator||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-07T16:43:45.350Z"
+		},
+		{
+			"id": 1340,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60836",
+			"name": "Decimator||Twitch Plays",
+			"action": "delete",
+			"timestamp": "2024-12-07T16:43:50.525Z",
+			"before": {
+				"id": 60836,
+				"old": false,
+				"solo": false,
+				"team": ["Twitch Plays"],
+				"time": 315.03,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=37a454fb2a381a369c9205636f58453541e939db;bomb=568ZJ5"
+				],
+				"verified": false,
+				"dateAdded": "2024-12-07T16:43:33.420Z",
+				"missionId": 9445,
+				"uploadedBy": "213189526837919745"
+			}
+		},
+		{
+			"id": 1341,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60835",
+			"name": "Arithmophobia||Twitch Plays",
+			"action": "delete",
+			"timestamp": "2024-12-07T16:43:55.312Z",
+			"before": {
+				"id": 60835,
+				"old": false,
+				"solo": false,
+				"team": ["Twitch Plays"],
+				"time": 1133.79,
+				"first": false,
+				"notes": null,
+				"proofs": ["https://ktane.timwi.de/lfa#file=47fa862345b23a8f26dcfda6cd5f5cb19a9a5857"],
+				"verified": false,
+				"dateAdded": "2024-12-07T16:43:33.420Z",
+				"missionId": 10008,
+				"uploadedBy": "213189526837919745"
+			}
+		},
+		{
+			"id": 1342,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60837",
+			"name": "Boringkloof||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-07T19:19:12.147Z"
+		},
+		{
+			"id": 1343,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9402",
+			"name": "Boringkloof",
+			"action": "update",
+			"timestamp": "2024-12-07T19:19:14.466Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1344,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60837",
+			"name": "Boringkloof||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-07T19:19:14.475Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1345,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60838",
+			"name": "You Can Learn This||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-07T21:09:25.718Z"
+		},
+		{
+			"id": 1346,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10396",
+			"name": "You Can Learn This",
+			"action": "update",
+			"timestamp": "2024-12-07T21:09:29.716Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1347,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60838",
+			"name": "You Can Learn This||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-07T21:09:29.732Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1348,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60839",
+			"name": "Into the Night||Faith, Kugel",
+			"action": "create",
+			"timestamp": "2024-12-08T01:55:55.762Z"
+		},
+		{
+			"id": 1349,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60839",
+			"name": "Into the Night||Faith, Kugel",
+			"action": "update",
+			"timestamp": "2024-12-08T09:07:54.401Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1350,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10808",
+			"name": "Elevator Bomb",
+			"action": "update",
+			"timestamp": "2024-12-08T15:56:17.662Z",
+			"before": { "notes": null },
+			"after": { "notes": "Bomb can only be started in VR" }
+		},
+		{
+			"id": 1351,
+			"userId": "434345780375977994",
+			"model": "Completion",
+			"recordId": "60840",
+			"name": "SoulOrg Endurance||Masked Mystery",
+			"action": "create",
+			"timestamp": "2024-12-08T18:22:53.209Z"
+		},
+		{
+			"id": 1352,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60840",
+			"name": "SoulOrg Endurance||Masked Mystery",
+			"action": "update",
+			"timestamp": "2024-12-08T20:39:25.454Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1353,
+			"userId": "434345780375977994",
+			"model": "Completion",
+			"recordId": "60841",
+			"name": "SoulOrg Endurance||Masked Mystery",
+			"action": "create",
+			"timestamp": "2024-12-08T20:44:16.662Z"
+		},
+		{
+			"id": 1354,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60842",
+			"name": "Starman||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-08T20:52:58.483Z"
+		},
+		{
+			"id": 1355,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60843",
+			"name": "Crumbled 47||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-08T20:53:08.052Z"
+		},
+		{
+			"id": 1356,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10608",
+			"name": "Starman",
+			"action": "update",
+			"timestamp": "2024-12-08T20:53:11.008Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1357,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60842",
+			"name": "Starman||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-08T20:53:11.018Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1358,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10551",
+			"name": "Crumbled 47",
+			"action": "update",
+			"timestamp": "2024-12-08T20:53:11.638Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1359,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60843",
+			"name": "Crumbled 47||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-08T20:53:11.647Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1360,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60841",
+			"name": "SoulOrg Endurance||Masked Mystery",
+			"action": "delete",
+			"timestamp": "2024-12-08T20:54:09.164Z",
+			"before": {
+				"id": 60841,
+				"old": false,
+				"solo": false,
+				"team": ["Masked Mystery"],
+				"time": 3630.45,
+				"first": false,
+				"notes": null,
+				"proofs": ["https://ktane.timwi.de/lfa#file=bd67cda29d2f7fa1944d3b2efaf35c7e17b5405b"],
+				"verified": false,
+				"dateAdded": "2024-12-08T20:43:34.599Z",
+				"missionId": 10460,
+				"uploadedBy": "434345780375977994"
+			}
+		},
+		{
+			"id": 1361,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10545",
+			"name": "Witek's 47",
+			"action": "update",
+			"timestamp": "2024-12-09T01:25:57.234Z",
+			"before": {
+				"logfile": "https://ktane.timwi.de/lfa#file=339bfae4280914a311adffbd530faa1bbc1735f8",
+				"inGameId": "mod_toc_NotVanillaModules_0_SectionTitle_2: \"Devilishly Devious\""
+			},
+			"after": {
+				"logfile": "https://ktane.timwi.de/lfa#file=fc8f7a25e72a025119bdc5a97f3f30782bef8351",
+				"inGameId": "mod_witeksmissionpack_Witek's 47"
+			}
+		},
+		{
+			"id": 1362,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10707",
+			"name": "Dzień dobry mam na imię płeć",
+			"action": "update",
+			"timestamp": "2024-12-09T01:30:03.366Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=fb68f9cf40a87d16e42318ae88c82d05dcd441ae" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=59c55f9da946d77d841187b6baeab9630acff5cc" }
+		},
+		{
+			"id": 1363,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10798",
+			"name": "Witek's Mental Asylum",
+			"action": "update",
+			"timestamp": "2024-12-09T01:45:50.318Z",
+			"before": {
+				"logfile": "https://ktane.timwi.de/lfa#file=4246ddb9f8fcb8ab9e1509cf13ff945a13a27925",
+				"inGameId": "mod_toc_YTJellify_0_SectionTitle_1: \"Speedy modded stuff\""
+			},
+			"after": {
+				"logfile": "https://ktane.timwi.de/lfa#file=41b78a6550307c84586701fd1669169f4e271851",
+				"inGameId": "mod_witeksmissionpack_Witek's Mental Asylum"
+			}
+		},
+		{
+			"id": 1364,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10544",
+			"name": "Modules Witek can solo",
+			"action": "update",
+			"timestamp": "2024-12-09T03:01:34.250Z",
+			"before": {
+				"logfile": "https://ktane.timwi.de/lfa#file=879cdc3dffcd2243b5be1520e5f74fbd21c8f112",
+				"inGameId": "mod_toc_BinMod_0_SectionTitle_1: \"With other mods\""
+			},
+			"after": {
+				"logfile": "https://ktane.timwi.de/lfa#file=3750a0335ed49cb7f2d8d71a16796c70be20d79d",
+				"inGameId": "mod_witeksmissionpack_Modules Witek can solo"
+			}
+		},
+		{
+			"id": 1365,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10453",
+			"name": "The Pridester",
+			"action": "update",
+			"timestamp": "2024-12-09T03:03:35.890Z",
+			"before": {
+				"logfile": "https://ktane.timwi.de/lfa#file=f9ae42c652796795520ba139e3dd82a9e254436a",
+				"inGameId": "mod_The_Pridester_The Pridester"
+			},
+			"after": {
+				"logfile": "https://ktane.timwi.de/lfa#file=e1df8e67b353b6642e93eb0179c60dbcf81dd6dd",
+				"inGameId": "mod_witeksmissionpack_The Pridester"
+			}
+		},
+		{
+			"id": 1366,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10827",
+			"name": "[[UPDATE]] The Rejected Modules",
+			"action": "create",
+			"timestamp": "2024-12-09T20:58:20.331Z"
+		},
+		{
+			"id": 1367,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10599",
+			"name": "The Rejected Modules",
+			"action": "update",
+			"timestamp": "2024-12-09T20:58:27.483Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=8f97e76071a66452512235de3e08883eb423bff0" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 7200,
+							"pools": [
+								{ "count": 1, "modules": ["ALL_VANILLA_NEEDY"] },
+								{ "count": 1, "modules": ["qkBitwiseOblivion"] },
+								{ "count": 1, "modules": ["top10nums"] },
+								{ "count": 1, "modules": ["LOOKATME"] },
+								{ "count": 1, "modules": ["xelMilitaryEncryption"] },
+								{ "count": 1, "modules": ["SapphireButtonModule"] },
+								{ "count": 1, "modules": ["edBalls"] },
+								{ "count": 1, "modules": ["rusticReversal"] },
+								{ "count": 1, "modules": ["blinkingNotes"] },
+								{ "count": 1, "modules": ["Overcooked"] },
+								{ "count": 1, "modules": ["hyperrullo"] },
+								{ "count": 1, "modules": ["xelKeystrokes"] },
+								{ "count": 1, "modules": ["yetAnotherKeypad"] },
+								{ "count": 1, "modules": ["poisonedGoblets"] },
+								{ "count": 1, "modules": ["LightGrid"] },
+								{ "count": 1, "modules": ["lettersAndNumbers"] },
+								{ "count": 1, "modules": ["conditionalMaze"] },
+								{ "count": 1, "modules": ["classicalSense"] },
+								{ "count": 1, "modules": ["nonagonInfinity"] },
+								{ "count": 1, "modules": ["pentrisSprint"] },
+								{ "count": 1, "modules": ["clockCounter"] },
+								{ "count": 1, "modules": ["tangledWires"] },
+								{ "count": 1, "modules": ["megamanBossRush"] },
+								{ "count": 1, "modules": ["mazeCode"] },
+								{ "count": 1, "modules": ["abuttoningMazes"] },
+								{ "count": 1, "modules": ["encryptcore"] },
+								{ "count": 1, "modules": ["SubtractionModule"] },
+								{ "count": 1, "modules": ["turingMachineNightmare"] },
+								{ "count": 1, "modules": ["templatemodule"] },
+								{ "count": 1, "modules": ["strongmadtalker"] },
+								{ "count": 1, "modules": ["solarReorder"] },
+								{ "count": 1, "modules": ["theTeardrop"] },
+								{ "count": 1, "modules": ["repseq"] },
+								{ "count": 1, "modules": ["notAdjacentLettersModule"] },
+								{ "count": 1, "modules": ["cryptid"] },
+								{ "count": 1, "modules": ["facetsAndLogic"] },
+								{ "count": 1, "modules": ["symmetryShuffle"] },
+								{ "count": 1, "modules": ["MultiverseHotline"] },
+								{ "count": 1, "modules": ["GSSatNav"] },
+								{ "count": 1, "modules": ["GSNormalProbability"] },
+								{ "count": 1, "modules": ["karnaugh"] },
+								{ "count": 1, "modules": ["worseCode"] },
+								{ "count": 1, "modules": ["GSGourmetHamburger"] },
+								{ "count": 1, "modules": ["foxedFreshly"] },
+								{ "count": 1, "modules": ["ColorSymbolicInterpretationModule"] },
+								{ "count": 1, "modules": ["NotSaimoeMaze"] },
+								{ "count": 1, "modules": ["polysolver"] }
+							],
+							"modules": 47,
+							"strikes": 5,
+							"widgets": 5
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=b80a0025b64efb26020dccaaf1f6af3892c2943b"
+			}
+		},
+		{
+			"id": 1368,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10827",
+			"name": "[[UPDATE]] The Rejected Modules",
+			"action": "delete",
+			"timestamp": "2024-12-09T20:58:27.506Z",
+			"before": {
+				"id": 10827,
+				"name": "[[UPDATE]] The Rejected Modules",
+				"notes": null,
+				"authors": ["Awesome7285"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=b80a0025b64efb26020dccaaf1f6af3892c2943b",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_awesome7285_missions_The Rejected Modules",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-12-09T20:57:57.775Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "486602438103531520",
+				"designedForTP": false,
+				"missionPackId": 595
+			}
+		},
+		{
+			"id": 1369,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10801",
+			"name": "InDiscrete Topology",
+			"action": "update",
+			"timestamp": "2024-12-09T20:59:55.317Z",
+			"before": { "notes": "The Octadecayotton is configured to 3 dimensions." },
+			"after": { "notes": "The Octadecayotton is configured to 6 dimensions." }
+		},
+		{
+			"id": 1370,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60844",
+			"name": "Baking Soda||Termet, AzaFTW",
+			"action": "create",
+			"timestamp": "2024-12-10T15:21:33.323Z"
+		},
+		{
+			"id": 1371,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60845",
+			"name": "Flyer's Half-Baked Insanity LTE||AzaFTW, Termet, Umbra Moruka",
+			"action": "create",
+			"timestamp": "2024-12-10T15:38:43.961Z"
+		},
+		{
+			"id": 1372,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60846",
+			"name": "Ekrixiphobia||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-10T22:41:46.735Z"
+		},
+		{
+			"id": 1373,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10000",
+			"name": "Ekrixiphobia",
+			"action": "update",
+			"timestamp": "2024-12-10T22:41:49.751Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1374,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60846",
+			"name": "Ekrixiphobia||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-10T22:41:49.760Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1375,
+			"userId": "725302560432324637",
+			"model": "Mission",
+			"recordId": "10828",
+			"name": "\"Can we do this bomb while I charge my phone?\"",
+			"action": "create",
+			"timestamp": "2024-12-11T08:49:12.117Z"
+		},
+		{
+			"id": 1376,
+			"userId": "725302560432324637",
+			"model": "Mission",
+			"recordId": "10829",
+			"name": "Crumbl Cookie Review",
+			"action": "create",
+			"timestamp": "2024-12-11T08:50:35.121Z"
+		},
+		{
+			"id": 1377,
+			"userId": "725302560432324637",
+			"model": "Mission",
+			"recordId": "10830",
+			"name": "Multifandom",
+			"action": "create",
+			"timestamp": "2024-12-11T08:51:06.466Z"
+		},
+		{
+			"id": 1378,
+			"userId": "725302560432324637",
+			"model": "Mission",
+			"recordId": "10831",
+			"name": "Tyler-Why",
+			"action": "create",
+			"timestamp": "2024-12-11T08:51:27.556Z"
+		},
+		{
+			"id": 1379,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60847",
+			"name": "Freedom||BladePL",
+			"action": "create",
+			"timestamp": "2024-12-12T17:07:11.007Z"
+		},
+		{
+			"id": 1380,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10832",
+			"name": "Axodoreduxion - Take 2",
+			"action": "create",
+			"timestamp": "2024-12-12T23:16:01.974Z"
+		},
+		{
+			"id": 1381,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60848",
+			"name": "Easy Challenge||Sierra, Enty, angel shaaark",
+			"action": "create",
+			"timestamp": "2024-12-13T01:45:53.414Z"
+		},
+		{
+			"id": 1382,
+			"userId": "566568608755613731",
+			"model": "Completion",
+			"recordId": "60849",
+			"name": "Experienced Group||Dani was here",
+			"action": "create",
+			"timestamp": "2024-12-13T12:22:40.157Z"
+		},
+		{
+			"id": 1383,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60844",
+			"name": "Baking Soda||Termet, AzaFTW",
+			"action": "update",
+			"timestamp": "2024-12-13T20:42:03.829Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1384,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60845",
+			"name": "Flyer's Half-Baked Insanity LTE||AzaFTW, Termet, Umbra Moruka",
+			"action": "update",
+			"timestamp": "2024-12-13T20:42:55.355Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1385,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60847",
+			"name": "Freedom||BladePL",
+			"action": "update",
+			"timestamp": "2024-12-13T20:45:35.759Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1386,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60848",
+			"name": "Easy Challenge||Sierra, Enty, angel shaaark",
+			"action": "update",
+			"timestamp": "2024-12-13T20:46:32.840Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1387,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60849",
+			"name": "Experienced Group||Dani was here",
+			"action": "update",
+			"timestamp": "2024-12-13T20:47:03.741Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1388,
+			"userId": "104464697775882240",
+			"model": "Completion",
+			"recordId": "60850",
+			"name": "CentuRUon||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-14T00:53:39.370Z"
+		},
+		{
+			"id": 1389,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10727",
+			"name": "CentuRUon",
+			"action": "update",
+			"timestamp": "2024-12-14T08:53:41.473Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1390,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60850",
+			"name": "CentuRUon||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-14T08:53:41.484Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1391,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60851",
+			"name": "Rogue||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-14T18:53:03.855Z"
+		},
+		{
+			"id": 1392,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60852",
+			"name": "CentuRUon||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-14T18:53:14.912Z"
+		},
+		{
+			"id": 1393,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60852",
+			"name": "CentuRUon||Twitch Plays",
+			"action": "delete",
+			"timestamp": "2024-12-14T18:53:17.621Z",
+			"before": {
+				"id": 60852,
+				"old": false,
+				"solo": false,
+				"team": ["Twitch Plays"],
+				"time": 2063.07,
+				"first": false,
+				"notes": null,
+				"proofs": ["https://ktane.timwi.de/lfa#file=bac63e0a0c65d96896ed72c08617702aec3af9e1"],
+				"verified": false,
+				"dateAdded": "2024-12-14T18:53:12.312Z",
+				"missionId": 10727,
+				"uploadedBy": "213189526837919745"
+			}
+		},
+		{
+			"id": 1394,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9638",
+			"name": "Rogue",
+			"action": "update",
+			"timestamp": "2024-12-14T18:53:18.781Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1395,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60851",
+			"name": "Rogue||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-14T18:53:18.790Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
 		}
 	],
 	"User": [
@@ -20197,7 +21268,7 @@
 			"id": "150385987950870528",
 			"username": "jasperbird",
 			"discordName": "jasperbird",
-			"avatar": "a1f3d8c3487641f5f57d93466b2121bd",
+			"avatar": "03f99dda2c59314a857cada33e292ae8",
 			"permissions": []
 		},
 		{
@@ -20673,7 +21744,7 @@
 			"id": "257492059101855745",
 			"username": "Zappyjro",
 			"discordName": "zappyjro",
-			"avatar": "d3373efc45441e300ee3e812879cf6fd",
+			"avatar": "a_0c029af1521088348141f591f6560f91",
 			"permissions": []
 		},
 		{
@@ -21132,6 +22203,13 @@
 			"permissions": []
 		},
 		{
+			"id": "351438865187209219",
+			"username": "Thomaz Brito",
+			"discordName": "thomazbrito",
+			"avatar": "3aea33ed273a964fce3ddb2d2e7c851f",
+			"permissions": []
+		},
+		{
 			"id": "356080305087447040",
 			"username": "aGood_Usernam3",
 			"discordName": "agood_usernam3",
@@ -21198,14 +22276,14 @@
 			"id": "369970767095529492",
 			"username": "MegaMatch",
 			"discordName": "megamatch0",
-			"avatar": "d33df6a6c85ef473b90e3e52f9797b31",
+			"avatar": "041f3d4bf834cdd9ab6f2afc2394ce67",
 			"permissions": []
 		},
 		{
 			"id": "370356150350249984",
 			"username": "Aaron Kitty Boiii",
 			"discordName": "aaronkittyboiii",
-			"avatar": "13aa5f07f142ce2a442af0ac4a1311a6",
+			"avatar": "cf81801714a459679cc1529dec0cbdcf",
 			"permissions": []
 		},
 		{
@@ -21926,8 +23004,8 @@
 		{
 			"id": "689219553531658292",
 			"username": "Faith",
-			"discordName": "faith21272",
-			"avatar": "67c7582e73f7b03814ae067c6d76bf7b",
+			"discordName": "shockthesharkgirl",
+			"avatar": "ee9c24167c2703952225d46b51310f66",
 			"permissions": []
 		},
 		{
@@ -22040,7 +23118,7 @@
 			"id": "725302560432324637",
 			"username": "Cookina",
 			"discordName": "momentcookie",
-			"avatar": "1c8ac0fc0f5565743ac591dcc12e2a57",
+			"avatar": "478c63728de66ebd80ad7b6acc9ca33e",
 			"permissions": []
 		},
 		{
@@ -22163,6 +23241,13 @@
 			"permissions": []
 		},
 		{
+			"id": "774790606156333057",
+			"username": "JacobDuffy",
+			"discordName": "jacobduffy1114",
+			"avatar": "78b3437d8a31962aa9468bb6d86a5667",
+			"permissions": []
+		},
+		{
 			"id": "776885288315387914",
 			"username": "The Slapstick Dictator",
 			"discordName": "theslapstickdictator",
@@ -22229,7 +23314,7 @@
 			"id": "832703757615497298",
 			"username": "Axodeau",
 			"discordName": "axodeau",
-			"avatar": "4bd12f6bf12f25e6e3c7b088f5eb08c1",
+			"avatar": "782a33300a98f8426d38f71dabb0af3b",
 			"permissions": []
 		},
 		{
@@ -22264,7 +23349,7 @@
 			"id": "898915665736515644",
 			"username": "Umbra Moruka",
 			"discordName": "umbra_moruka_official",
-			"avatar": "c8c32243338017a043526db8d72df74e",
+			"avatar": "a1a3c5afb8cd3b5bb07a2802f993aa3d",
 			"permissions": []
 		},
 		{ "id": "908468871424532560", "username": "MichMan", "discordName": "jwong0611", "avatar": "0", "permissions": [] },

--- a/importer/advanced.json
+++ b/importer/advanced.json
@@ -10197,6 +10197,9654 @@
 			"timestamp": "2024-10-17T12:14:44.953Z",
 			"before": { "verified": false },
 			"after": { "verified": true }
+		},
+		{
+			"id": 641,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60591",
+			"name": "Sweet 16||BladePL",
+			"action": "update",
+			"timestamp": "2024-10-17T19:00:44.444Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 642,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60592",
+			"name": "Centurion||BladePL",
+			"action": "update",
+			"timestamp": "2024-10-17T19:01:45.734Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 643,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60593",
+			"name": "Switch Madness||tactualdwarf519",
+			"action": "update",
+			"timestamp": "2024-10-17T19:02:31.829Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 644,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60590",
+			"name": "Boss Soloing||denial140",
+			"action": "update",
+			"timestamp": "2024-10-17T19:05:25.430Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 645,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60594",
+			"name": "Ruby's Favourite 47||Kugel",
+			"action": "update",
+			"timestamp": "2024-10-17T19:06:43.250Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 646,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60595",
+			"name": "Russian Roulette||Kugel",
+			"action": "update",
+			"timestamp": "2024-10-17T19:07:21.985Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 647,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60596",
+			"name": "This Isn't Just A Mission, This Is An M&S Mission||Sierra",
+			"action": "update",
+			"timestamp": "2024-10-17T19:08:19.838Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 648,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60597",
+			"name": "17 Again||BladePL",
+			"action": "update",
+			"timestamp": "2024-10-17T19:08:57.196Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 649,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60598",
+			"name": "Keypad Madness||tactualdwarf519",
+			"action": "update",
+			"timestamp": "2024-10-17T19:09:16.007Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 650,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10768",
+			"name": "What The Boss - Bossadder Goes Forth",
+			"action": "update",
+			"timestamp": "2024-10-17T19:13:53.260Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 6000,
+								"pools": [
+									{ "count": 1, "modules": ["christmasPresents"] },
+									{ "count": 1, "modules": ["TheClockModule"] },
+									{ "count": 1, "modules": ["digitalClock"] },
+									{ "count": 1, "modules": ["EncryptedTimezones"] },
+									{ "count": 1, "modules": ["NotTimerModule"] },
+									{ "count": 1, "modules": ["primeTime"] },
+									{ "count": 1, "modules": ["stopwatch"] },
+									{ "count": 1, "modules": ["subways"] },
+									{ "count": 1, "modules": ["temporalSequence"] },
+									{ "count": 1, "modules": ["timezone"] },
+									{ "count": 1, "modules": ["TrainingText"] }
+								],
+								"modules": 11,
+								"strikes": 3,
+								"widgets": 5
+							},
+							"where": { "id": 14753 }
+						},
+						{
+							"data": {
+								"time": 6000,
+								"pools": [
+									{ "count": 1, "modules": ["krazzBlaseball"] },
+									{ "count": 1, "modules": ["Bowling"] },
+									{ "count": 1, "modules": ["boxing"] },
+									{ "count": 1, "modules": ["kataBurnout"] },
+									{ "count": 1, "modules": ["golf"] },
+									{ "count": 1, "modules": ["KritGrandPrix"] },
+									{ "count": 1, "modules": ["HoleInOne"] },
+									{ "count": 1, "modules": ["theMidnightMotoristModule"] },
+									{ "count": 1, "modules": ["snooker"] },
+									{ "count": 1, "modules": ["typeRacer"] },
+									{ "count": 1, "modules": ["X01"] }
+								],
+								"modules": 11,
+								"strikes": 3,
+								"widgets": 5
+							},
+							"where": { "id": 14754 }
+						},
+						{
+							"data": {
+								"time": 6000,
+								"pools": [
+									{ "count": 1, "modules": ["burgerAlarm"] },
+									{ "count": 1, "modules": ["burglarAlarm"] },
+									{ "count": 1, "modules": ["Emoji Math"] },
+									{ "count": 1, "modules": ["fastMath"] },
+									{ "count": 1, "modules": ["JustNumbersModule"] },
+									{ "count": 1, "modules": ["nobodysCodeModule"] },
+									{ "count": 1, "modules": ["notEmojiMath"] },
+									{ "count": 1, "modules": ["Omission"] },
+									{ "count": 1, "modules": ["PixelNumberBase"] },
+									{ "count": 1, "modules": ["QuickArithmetic"] },
+									{ "count": 1, "modules": ["SkewedSlotsModule"] }
+								],
+								"modules": 11,
+								"strikes": 3,
+								"widgets": 5
+							},
+							"where": { "id": 14755 }
+						},
+						{
+							"data": {
+								"time": 6000,
+								"pools": [
+									{ "count": 1, "modules": ["15MysticLights"] },
+									{ "count": 1, "modules": ["colorHexagons"] },
+									{ "count": 1, "modules": ["ColoredSquaresModule"] },
+									{ "count": 1, "modules": ["colors_maximization"] },
+									{ "count": 1, "modules": ["fireDiamondsModule"] },
+									{ "count": 1, "modules": ["forget_fractal"] },
+									{ "count": 1, "modules": ["fractalMaze"] },
+									{ "count": 1, "modules": ["SimonShapesModule"] },
+									{ "count": 1, "modules": ["simonSimons"] },
+									{ "count": 1, "modules": ["simonSubdivides"] },
+									{ "count": 1, "modules": ["synesthesia"] }
+								],
+								"modules": 11,
+								"strikes": 3,
+								"widgets": 5
+							},
+							"where": { "id": 14756 }
+						},
+						{
+							"data": {
+								"time": 6000,
+								"pools": [
+									{ "count": 1, "modules": ["BlackoutModule"] },
+									{ "count": 1, "modules": ["BooleanKeypad"] },
+									{ "count": 1, "modules": ["indigoCipher"] },
+									{ "count": 1, "modules": ["logicGates"] },
+									{ "count": 1, "modules": ["maskedMorse"] },
+									{ "count": 1, "modules": ["rgbCombination"] },
+									{ "count": 1, "modules": ["SuperlogicModule"] },
+									{ "count": 1, "modules": ["unorderedKeys"] },
+									{ "count": 1, "modules": ["WanderModule"] },
+									{ "count": 1, "modules": ["whiteout"] },
+									{ "count": 1, "modules": ["xrgb"] }
+								],
+								"modules": 11,
+								"strikes": 3,
+								"widgets": 5
+							},
+							"where": { "id": 14757 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 651,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10768",
+			"name": "What The Boss - Bossadder Goes Forth",
+			"action": "update",
+			"timestamp": "2024-10-17T19:13:53.283Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=734b7a0689460375132ca24cb71149c40b177362" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=d2cf82f3a037eaf78239a683adc7d5cd44e3b8ce" }
+		},
+		{
+			"id": 652,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60575",
+			"name": "Pocket Change||Umbra Moruka, Termet, AzaFTW",
+			"action": "update",
+			"timestamp": "2024-10-17T19:17:02.187Z",
+			"before": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=cfdffe43bcccdc985092ca8e36636d5036ce228a;bomb=BT5GG7"
+				]
+			},
+			"after": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=cfdffe43bcccdc985092ca8e36636d5036ce228a;bomb=BT5GG7",
+					"https://www.youtube.com/watch?v=jhkUgOiMOaI&feature=youtu.be"
+				]
+			}
+		},
+		{
+			"id": 653,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60599",
+			"name": "Praetorian New Ones||BladePL",
+			"action": "create",
+			"timestamp": "2024-10-17T19:33:43.969Z"
+		},
+		{
+			"id": 654,
+			"userId": "104464697775882240",
+			"model": "Completion",
+			"recordId": "60600",
+			"name": ":((=||Framzo, nameless",
+			"action": "create",
+			"timestamp": "2024-10-17T20:01:37.966Z"
+		},
+		{
+			"id": 655,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60601",
+			"name": "Easy Challenge||denial140",
+			"action": "create",
+			"timestamp": "2024-10-18T00:13:41.809Z"
+		},
+		{
+			"id": 656,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60602",
+			"name": "ÜberKlax Endurance||denial140",
+			"action": "create",
+			"timestamp": "2024-10-18T18:49:36.638Z"
+		},
+		{
+			"id": 657,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60006",
+			"name": "ÜberKlax Endurance||denial140",
+			"action": "update",
+			"timestamp": "2024-10-18T18:49:50.093Z",
+			"before": {
+				"time": 3877.62,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=99015c7b100106d160978f36c4fbc4b28eb690a7;bomb=0U0VD7"
+				]
+			},
+			"after": {
+				"time": 3668.06,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=622f29db93eb20201d1ca9905ebf850a987953f8;bomb=EC0EC7"
+				]
+			}
+		},
+		{
+			"id": 658,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60602",
+			"name": "ÜberKlax Endurance||denial140",
+			"action": "delete",
+			"timestamp": "2024-10-18T18:49:50.102Z",
+			"before": {
+				"id": 60602,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 3668.06,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=622f29db93eb20201d1ca9905ebf850a987953f8;bomb=EC0EC7"
+				],
+				"verified": false,
+				"dateAdded": "2024-10-18T18:49:25.707Z",
+				"missionId": 10577,
+				"uploadedBy": "486602438103531520"
+			}
+		},
+		{
+			"id": 659,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60603",
+			"name": "ÜberKlax Endurance||denial140, Burniel",
+			"action": "create",
+			"timestamp": "2024-10-18T18:51:16.250Z"
+		},
+		{
+			"id": 660,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60603",
+			"name": "ÜberKlax Endurance||denial140, Burniel",
+			"action": "update",
+			"timestamp": "2024-10-18T18:51:20.691Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 661,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60603",
+			"name": "ÜberKlax Endurance||denial140, Burniel",
+			"action": "update",
+			"timestamp": "2024-10-18T18:51:39.288Z",
+			"before": { "team": ["denial140", "Burniel"] },
+			"after": { "team": ["denial140", ""] }
+		},
+		{
+			"id": 662,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60603",
+			"name": "ÜberKlax Endurance||denial140, ",
+			"action": "update",
+			"timestamp": "2024-10-18T18:51:51.124Z",
+			"before": { "team": ["denial140", ""], "first": false },
+			"after": { "team": ["denial140"], "first": true }
+		},
+		{
+			"id": 663,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60006",
+			"name": "ÜberKlax Endurance||denial140",
+			"action": "update",
+			"timestamp": "2024-10-18T18:51:56.135Z",
+			"before": { "first": true },
+			"after": { "first": false }
+		},
+		{
+			"id": 664,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60603",
+			"name": "ÜberKlax Endurance||denial140",
+			"action": "update",
+			"timestamp": "2024-10-18T18:52:01.799Z",
+			"before": { "dateAdded": "2024-10-18T18:51:01.409Z" },
+			"after": { "dateAdded": "2024-07-14T04:00:00.000Z" }
+		},
+		{
+			"id": 665,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60603",
+			"name": "ÜberKlax Endurance||denial140",
+			"action": "update",
+			"timestamp": "2024-10-18T18:52:14.480Z",
+			"before": { "first": true },
+			"after": { "first": false }
+		},
+		{
+			"id": 666,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60006",
+			"name": "ÜberKlax Endurance||denial140",
+			"action": "update",
+			"timestamp": "2024-10-18T18:52:17.781Z",
+			"before": { "first": false },
+			"after": { "first": true }
+		},
+		{
+			"id": 667,
+			"userId": "455035517872898050",
+			"model": "Mission",
+			"recordId": "10778",
+			"name": "The Definition of Insanity",
+			"action": "create",
+			"timestamp": "2024-10-18T21:00:34.196Z"
+		},
+		{
+			"id": 668,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60604",
+			"name": "Wire Madness||denial140",
+			"action": "create",
+			"timestamp": "2024-10-19T03:19:44.706Z"
+		},
+		{
+			"id": 669,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60605",
+			"name": "Timing is Everything||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-19T04:19:57.503Z"
+		},
+		{
+			"id": 670,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60606",
+			"name": "Alternative Affinities||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-19T04:20:05.467Z"
+		},
+		{
+			"id": 671,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60607",
+			"name": "GhostSalt's Rebooting Challenge||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-19T04:20:15.166Z"
+		},
+		{
+			"id": 672,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9287",
+			"name": "Timing is Everything",
+			"action": "update",
+			"timestamp": "2024-10-19T04:20:19.472Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 673,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60605",
+			"name": "Timing is Everything||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-19T04:20:19.481Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 674,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9782",
+			"name": "Alternative Affinities",
+			"action": "update",
+			"timestamp": "2024-10-19T04:20:20.113Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 675,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60606",
+			"name": "Alternative Affinities||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-19T04:20:20.123Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 676,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10505",
+			"name": "GhostSalt's Rebooting Challenge",
+			"action": "update",
+			"timestamp": "2024-10-19T04:20:20.626Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 677,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60607",
+			"name": "GhostSalt's Rebooting Challenge||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-19T04:20:20.635Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 678,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10707",
+			"name": "Dzień dobry mam na imię płeć",
+			"action": "update",
+			"timestamp": "2024-10-19T05:26:47.431Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 679,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10732",
+			"name": "Boss Rush",
+			"action": "update",
+			"timestamp": "2024-10-19T05:26:50.961Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 680,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10745",
+			"name": "Ultimate Madness",
+			"action": "update",
+			"timestamp": "2024-10-19T05:26:54.681Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 681,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10746",
+			"name": "Orange",
+			"action": "update",
+			"timestamp": "2024-10-19T05:26:56.240Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 682,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10747",
+			"name": "I Love Countdown!",
+			"action": "update",
+			"timestamp": "2024-10-19T05:26:57.499Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 683,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10743",
+			"name": "Widget Madness",
+			"action": "update",
+			"timestamp": "2024-10-19T05:28:47.094Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 7200,
+								"pools": [
+									{ "count": 1, "modules": ["spwizAdventureGame"] },
+									{ "count": 1, "modules": ["algebra"] },
+									{ "count": 1, "modules": ["antichamber"] },
+									{ "count": 1, "modules": ["BigCircle"] },
+									{ "count": 1, "modules": ["BlindAlleyModule"] },
+									{ "count": 1, "modules": ["blindfoldedRubiksClockModule"] },
+									{ "count": 1, "modules": ["blockbusters"] },
+									{ "count": 1, "modules": ["bombDiffusal"] },
+									{ "count": 1, "modules": ["Bowling"] },
+									{ "count": 1, "modules": ["colourcode"] },
+									{ "count": 1, "modules": ["combinationLock"] },
+									{ "count": 1, "modules": ["Venn"] },
+									{ "count": 1, "modules": ["cooking"] },
+									{ "count": 1, "modules": ["TheDigitModule"] },
+									{ "count": 1, "modules": ["digitDilemma"] },
+									{ "count": 1, "modules": ["EarthboundModule"] },
+									{ "count": 1, "modules": ["EdgeworkModule", "forgetThemAll"] },
+									{ "count": 1, "modules": ["goofysgame"] },
+									{ "count": 1, "modules": ["inverse"] },
+									{ "count": 1, "modules": ["ladderLottery"] },
+									{ "count": 1, "modules": ["ladders"] },
+									{ "count": 1, "modules": ["langtonAnt"] },
+									{ "count": 1, "modules": ["Laundry"] },
+									{ "count": 1, "modules": ["levenshteinDistance"] },
+									{ "count": 1, "modules": ["lyingIndicators"] },
+									{ "count": 1, "modules": ["Mastermind Cruel"] },
+									{ "count": 1, "modules": ["neutralization"] },
+									{ "count": 1, "modules": ["NotLaundry"] },
+									{ "count": 1, "modules": ["xtrpasscodes"] },
+									{ "count": 1, "modules": ["pwGenerator"] },
+									{ "count": 1, "modules": ["phones"] },
+									{ "count": 1, "modules": ["PianoKeys"] },
+									{ "count": 1, "modules": ["planets"] },
+									{ "count": 1, "modules": ["MazeV2"] },
+									{ "count": 1, "modules": ["portCheck"] },
+									{ "count": 1, "modules": ["pressTheShape"] },
+									{ "count": 1, "modules": ["radiator"] },
+									{ "count": 1, "modules": ["shapeshift"] },
+									{ "count": 1, "modules": ["SkewedSlotsModule"] },
+									{ "count": 1, "modules": ["someButtons"] },
+									{ "count": 1, "modules": ["sun"] },
+									{ "count": 1, "modules": ["smbh"] },
+									{ "count": 1, "modules": ["GSTellMeWhere"] },
+									{ "count": 1, "modules": ["GSTellMeWhy"] },
+									{ "count": 1, "modules": ["theTissueBox"] },
+									{ "count": 1, "modules": ["TribalCouncil"] },
+									{ "count": 1, "modules": ["widgetry"] }
+								],
+								"modules": 47,
+								"strikes": 6,
+								"widgets": 39
+							},
+							"where": { "id": 14707 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 684,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10743",
+			"name": "Widget Madness",
+			"action": "update",
+			"timestamp": "2024-10-19T05:29:10.954Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 4800,
+								"pools": [
+									{ "count": 1, "modules": ["spwizAdventureGame"] },
+									{ "count": 1, "modules": ["algebra"] },
+									{ "count": 1, "modules": ["antichamber"] },
+									{ "count": 1, "modules": ["BigCircle"] },
+									{ "count": 1, "modules": ["BlindAlleyModule"] },
+									{ "count": 1, "modules": ["blindfoldedRubiksClockModule"] },
+									{ "count": 1, "modules": ["blockbusters"] },
+									{ "count": 1, "modules": ["bombDiffusal"] },
+									{ "count": 1, "modules": ["Bowling"] },
+									{ "count": 1, "modules": ["colourcode"] },
+									{ "count": 1, "modules": ["combinationLock"] },
+									{ "count": 1, "modules": ["Venn"] },
+									{ "count": 1, "modules": ["cooking"] },
+									{ "count": 1, "modules": ["TheDigitModule"] },
+									{ "count": 1, "modules": ["digitDilemma"] },
+									{ "count": 1, "modules": ["EarthboundModule"] },
+									{ "count": 1, "modules": ["EdgeworkModule", "forgetThemAll"] },
+									{ "count": 1, "modules": ["goofysgame"] },
+									{ "count": 1, "modules": ["inverse"] },
+									{ "count": 1, "modules": ["ladderLottery"] },
+									{ "count": 1, "modules": ["ladders"] },
+									{ "count": 1, "modules": ["langtonAnt"] },
+									{ "count": 1, "modules": ["Laundry"] },
+									{ "count": 1, "modules": ["levenshteinDistance"] },
+									{ "count": 1, "modules": ["lyingIndicators"] },
+									{ "count": 1, "modules": ["Mastermind Cruel"] },
+									{ "count": 1, "modules": ["neutralization"] },
+									{ "count": 1, "modules": ["NotLaundry"] },
+									{ "count": 1, "modules": ["xtrpasscodes"] },
+									{ "count": 1, "modules": ["pwGenerator"] },
+									{ "count": 1, "modules": ["phones"] },
+									{ "count": 1, "modules": ["PianoKeys"] },
+									{ "count": 1, "modules": ["planets"] },
+									{ "count": 1, "modules": ["MazeV2"] },
+									{ "count": 1, "modules": ["portCheck"] },
+									{ "count": 1, "modules": ["pressTheShape"] },
+									{ "count": 1, "modules": ["radiator"] },
+									{ "count": 1, "modules": ["shapeshift"] },
+									{ "count": 1, "modules": ["SkewedSlotsModule"] },
+									{ "count": 1, "modules": ["someButtons"] },
+									{ "count": 1, "modules": ["sun"] },
+									{ "count": 1, "modules": ["smbh"] },
+									{ "count": 1, "modules": ["GSTellMeWhere"] },
+									{ "count": 1, "modules": ["GSTellMeWhy"] },
+									{ "count": 1, "modules": ["theTissueBox"] },
+									{ "count": 1, "modules": ["TribalCouncil"] },
+									{ "count": 1, "modules": ["widgetry"] }
+								],
+								"modules": 47,
+								"strikes": 6,
+								"widgets": 39
+							},
+							"where": { "id": 14707 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 685,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10743",
+			"name": "Widget Madness",
+			"action": "update",
+			"timestamp": "2024-10-19T05:29:10.963Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=0af8e9c3fbab71e801977f091ff35dae8a57ea90" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=91c9a105b34b9365f7f32c341e56da81918c37ea" }
+		},
+		{
+			"id": 686,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10743",
+			"name": "Widget Madness",
+			"action": "update",
+			"timestamp": "2024-10-19T05:29:17.738Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 687,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60608",
+			"name": "Ultimate Madness||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-19T06:09:32.405Z"
+		},
+		{
+			"id": 688,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10745",
+			"name": "Ultimate Madness",
+			"action": "update",
+			"timestamp": "2024-10-19T06:09:35.727Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 689,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60608",
+			"name": "Ultimate Madness||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-19T06:09:35.745Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 690,
+			"userId": "1043099159084929024",
+			"model": "Completion",
+			"recordId": "60609",
+			"name": "Olievenhoutbosch||Srećko",
+			"action": "create",
+			"timestamp": "2024-10-19T08:04:19.411Z"
+		},
+		{
+			"id": 691,
+			"userId": "564025785573179407",
+			"model": "Completion",
+			"recordId": "60610",
+			"name": "Possibly Impossible||Chokokafe",
+			"action": "create",
+			"timestamp": "2024-10-19T13:53:00.940Z"
+		},
+		{
+			"id": 692,
+			"userId": "564025785573179407",
+			"model": "Completion",
+			"recordId": "60611",
+			"name": "Possibly Impossible: Ultra Deluxe Edition||Chokokafe",
+			"action": "create",
+			"timestamp": "2024-10-19T15:48:44.451Z"
+		},
+		{
+			"id": 693,
+			"userId": "208633883544125440",
+			"model": "Mission",
+			"recordId": "10779",
+			"name": "[[UPDATE]] Orange",
+			"action": "create",
+			"timestamp": "2024-10-19T19:12:32.103Z"
+		},
+		{
+			"id": 694,
+			"userId": "208633883544125440",
+			"model": "Mission",
+			"recordId": "10780",
+			"name": "[[UPDATE]] New Supersonic",
+			"action": "create",
+			"timestamp": "2024-10-19T19:23:53.719Z"
+		},
+		{
+			"id": 695,
+			"userId": "243193229661569024",
+			"model": "Completion",
+			"recordId": "60612",
+			"name": "Chronos||Dicey",
+			"action": "create",
+			"timestamp": "2024-10-19T19:34:50.741Z"
+		},
+		{
+			"id": 696,
+			"userId": "386319360974651394",
+			"model": "Completion",
+			"recordId": "60600",
+			"name": ":((=||Framzo, nameless",
+			"action": "update",
+			"timestamp": "2024-10-19T23:23:10.227Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 697,
+			"userId": "386319360974651394",
+			"model": "Completion",
+			"recordId": "60599",
+			"name": "Praetorian New Ones||BladePL",
+			"action": "update",
+			"timestamp": "2024-10-19T23:23:11.740Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 698,
+			"userId": "386319360974651394",
+			"model": "Completion",
+			"recordId": "59658",
+			"name": "Easy Challenge||denial140",
+			"action": "update",
+			"timestamp": "2024-10-19T23:23:16.596Z",
+			"before": {
+				"time": 1654.67,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=71dae1db26e3dab35cba9dd97b2ebfa23d932a0c;bomb=AV6EM0"
+				]
+			},
+			"after": {
+				"time": 1714.19,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=7791560aa06f0bc117482055854b9b6129c2cd29;bomb=NF2EP3",
+					"https://youtu.be/1nBCttITYvo"
+				]
+			}
+		},
+		{
+			"id": 699,
+			"userId": "386319360974651394",
+			"model": "Completion",
+			"recordId": "60601",
+			"name": "Easy Challenge||denial140",
+			"action": "delete",
+			"timestamp": "2024-10-19T23:23:16.605Z",
+			"before": {
+				"id": 60601,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 1714.19,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=7791560aa06f0bc117482055854b9b6129c2cd29;bomb=NF2EP3",
+					"https://youtu.be/1nBCttITYvo"
+				],
+				"verified": false,
+				"dateAdded": "2024-10-18T00:06:35.735Z",
+				"missionId": 9636,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 700,
+			"userId": "386319360974651394",
+			"model": "Completion",
+			"recordId": "60604",
+			"name": "Wire Madness||denial140",
+			"action": "update",
+			"timestamp": "2024-10-19T23:23:18.501Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 701,
+			"userId": "386319360974651394",
+			"model": "Completion",
+			"recordId": "60609",
+			"name": "Olievenhoutbosch||Srećko",
+			"action": "update",
+			"timestamp": "2024-10-19T23:23:20.126Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 702,
+			"userId": "386319360974651394",
+			"model": "Completion",
+			"recordId": "60610",
+			"name": "Possibly Impossible||Chokokafe",
+			"action": "update",
+			"timestamp": "2024-10-19T23:23:21.363Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 703,
+			"userId": "386319360974651394",
+			"model": "Completion",
+			"recordId": "60611",
+			"name": "Possibly Impossible: Ultra Deluxe Edition||Chokokafe",
+			"action": "update",
+			"timestamp": "2024-10-19T23:23:22.955Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 704,
+			"userId": "386319360974651394",
+			"model": "Completion",
+			"recordId": "60612",
+			"name": "Chronos||Dicey",
+			"action": "update",
+			"timestamp": "2024-10-19T23:23:24.220Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 705,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60613",
+			"name": "Great Berate's Endurance Challenge||BladePL",
+			"action": "create",
+			"timestamp": "2024-10-20T16:00:30.591Z"
+		},
+		{
+			"id": 706,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60614",
+			"name": "I Love Countdown!||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-20T19:03:11.311Z"
+		},
+		{
+			"id": 707,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10747",
+			"name": "I Love Countdown!",
+			"action": "update",
+			"timestamp": "2024-10-20T19:03:15.414Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 708,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60614",
+			"name": "I Love Countdown!||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-20T19:03:15.430Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 709,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10781",
+			"name": "[[UPDATE]] Triple Trouble",
+			"action": "create",
+			"timestamp": "2024-10-20T19:35:01.969Z"
+		},
+		{
+			"id": 710,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60615",
+			"name": "Longhena||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-20T19:54:56.160Z"
+		},
+		{
+			"id": 711,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9581",
+			"name": "Longhena",
+			"action": "update",
+			"timestamp": "2024-10-20T19:55:03.158Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 712,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60615",
+			"name": "Longhena||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-20T19:55:03.167Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 713,
+			"userId": "488806494872272898",
+			"model": "Completion",
+			"recordId": "60616",
+			"name": "By Popular Demand||Men in Black",
+			"action": "create",
+			"timestamp": "2024-10-20T20:39:31.350Z"
+		},
+		{
+			"id": 714,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60617",
+			"name": "Burrows of the Mystic Occult||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-20T21:40:45.684Z"
+		},
+		{
+			"id": 715,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10631",
+			"name": "Burrows of the Mystic Occult",
+			"action": "update",
+			"timestamp": "2024-10-20T21:40:56.819Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 716,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60617",
+			"name": "Burrows of the Mystic Occult||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-20T21:40:56.828Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 717,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10782",
+			"name": "[[UPDATE]] Canonically Diabolical",
+			"action": "create",
+			"timestamp": "2024-10-20T22:05:57.318Z"
+		},
+		{
+			"id": 718,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60618",
+			"name": "Nothing To Spare: Quickly Now!||Termet",
+			"action": "create",
+			"timestamp": "2024-10-20T22:11:19.797Z"
+		},
+		{
+			"id": 719,
+			"userId": "234075130521714689",
+			"model": "Completion",
+			"recordId": "60619",
+			"name": "Undefined 47||Lyph",
+			"action": "create",
+			"timestamp": "2024-10-21T04:04:19.576Z"
+		},
+		{
+			"id": 720,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60620",
+			"name": "Centurion||Termet, c12",
+			"action": "create",
+			"timestamp": "2024-10-21T12:46:44.515Z"
+		},
+		{
+			"id": 721,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60621",
+			"name": "Great Berate Practice||BladePL",
+			"action": "create",
+			"timestamp": "2024-10-21T15:47:45.506Z"
+		},
+		{
+			"id": 722,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60622",
+			"name": "Intro to Modded KTANE||BladePL",
+			"action": "create",
+			"timestamp": "2024-10-21T18:53:49.051Z"
+		},
+		{
+			"id": 723,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60613",
+			"name": "Great Berate's Endurance Challenge||BladePL",
+			"action": "update",
+			"timestamp": "2024-10-21T19:32:15.338Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 724,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60616",
+			"name": "By Popular Demand||Men in Black",
+			"action": "update",
+			"timestamp": "2024-10-21T19:32:41.311Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 725,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60623",
+			"name": "I Love Countdown!||Faith",
+			"action": "create",
+			"timestamp": "2024-10-21T21:06:51.711Z"
+		},
+		{
+			"id": 726,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10728",
+			"name": "What a Bunch of Bull",
+			"action": "update",
+			"timestamp": "2024-10-21T21:23:05.415Z",
+			"before": { "notes": null },
+			"after": { "notes": "Updated version pending review. Solves temporarily frozen." }
+		},
+		{
+			"id": 727,
+			"userId": "123571941599608834",
+			"model": "Completion",
+			"recordId": "60624",
+			"name": "47||Procyon",
+			"action": "create",
+			"timestamp": "2024-10-22T00:26:36.543Z"
+		},
+		{
+			"id": 728,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60625",
+			"name": "Dove||denial140",
+			"action": "create",
+			"timestamp": "2024-10-22T04:18:59.011Z"
+		},
+		{
+			"id": 729,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60626",
+			"name": "Sweet 16||Termet, c12",
+			"action": "create",
+			"timestamp": "2024-10-22T10:33:29.996Z"
+		},
+		{
+			"id": 730,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60627",
+			"name": "By Popular Demand||Termet, c12",
+			"action": "create",
+			"timestamp": "2024-10-22T10:38:42.680Z"
+		},
+		{
+			"id": 731,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60628",
+			"name": ":((=||c12, Termet, Danielstigman",
+			"action": "create",
+			"timestamp": "2024-10-22T11:48:07.981Z"
+		},
+		{
+			"id": 732,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60629",
+			"name": "Sky's the Minimum||Sierra",
+			"action": "create",
+			"timestamp": "2024-10-22T14:29:08.228Z"
+		},
+		{
+			"id": 733,
+			"userId": "138339442346819584",
+			"model": "Mission",
+			"recordId": "10783",
+			"name": "Step By Step",
+			"action": "create",
+			"timestamp": "2024-10-22T19:32:52.576Z"
+		},
+		{
+			"id": 734,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10784",
+			"name": "[[UPDATE]] How do you keep an idiot busy?",
+			"action": "create",
+			"timestamp": "2024-10-22T22:41:42.407Z"
+		},
+		{
+			"id": 735,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10785",
+			"name": "#things-blan-does-not-know",
+			"action": "create",
+			"timestamp": "2024-10-22T22:43:57.379Z"
+		},
+		{
+			"id": 736,
+			"userId": "104464697775882240",
+			"model": "Completion",
+			"recordId": "60630",
+			"name": "Undefined 47||Framzo, nameless",
+			"action": "create",
+			"timestamp": "2024-10-23T00:13:14.733Z"
+		},
+		{
+			"id": 737,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10785",
+			"name": "#things-blan-does-not-know",
+			"action": "update",
+			"timestamp": "2024-10-23T01:47:18.666Z",
+			"before": { "missionPackId": 420 },
+			"after": { "missionPackId": 538 }
+		},
+		{
+			"id": 738,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10784",
+			"name": "[[UPDATE]] How do you keep an idiot busy?",
+			"action": "update",
+			"timestamp": "2024-10-23T01:47:47.041Z",
+			"before": { "missionPackId": 420 },
+			"after": { "missionPackId": 538 }
+		},
+		{
+			"id": 739,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60631",
+			"name": "Eldoraigne||Termet, c12",
+			"action": "create",
+			"timestamp": "2024-10-23T12:28:31.527Z"
+		},
+		{
+			"id": 740,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60632",
+			"name": "Doringkloof||Termet, c12",
+			"action": "create",
+			"timestamp": "2024-10-23T13:34:05.999Z"
+		},
+		{
+			"id": 741,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60633",
+			"name": "Fnuuy||Sierra, AzaFTW",
+			"action": "create",
+			"timestamp": "2024-10-23T18:54:10.741Z"
+		},
+		{
+			"id": 742,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60634",
+			"name": "FMN Hell 3||BladePL",
+			"action": "create",
+			"timestamp": "2024-10-23T19:40:08.967Z"
+		},
+		{
+			"id": 743,
+			"userId": "261983800429510658",
+			"model": "Completion",
+			"recordId": "60635",
+			"name": "Undefined 47||nameless, Framzo",
+			"action": "create",
+			"timestamp": "2024-10-23T22:10:09.774Z"
+		},
+		{
+			"id": 744,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60636",
+			"name": "Asmir's 47||denial140",
+			"action": "create",
+			"timestamp": "2024-10-24T08:21:22.992Z"
+		},
+		{
+			"id": 745,
+			"userId": "1257537901265162271",
+			"model": "Completion",
+			"recordId": "60637",
+			"name": "Doringkloof||c12, Termet",
+			"action": "create",
+			"timestamp": "2024-10-24T11:17:00.791Z"
+		},
+		{
+			"id": 746,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60638",
+			"name": "Olievenhoutbosch||AzaFTW, Termet",
+			"action": "create",
+			"timestamp": "2024-10-24T14:56:59.162Z"
+		},
+		{
+			"id": 747,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60639",
+			"name": "Outgoing Call||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-24T17:14:53.847Z"
+		},
+		{
+			"id": 748,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9664",
+			"name": "Outgoing Call",
+			"action": "update",
+			"timestamp": "2024-10-24T17:14:58.912Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 749,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60639",
+			"name": "Outgoing Call||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-24T17:14:58.922Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 750,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "9563",
+			"name": "Try Not To Forget",
+			"action": "update",
+			"timestamp": "2024-10-24T18:27:06.617Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 6300,
+								"pools": [
+									{ "count": 1, "modules": ["MistakeModule"] },
+									{ "count": 1, "modules": ["borderedKeys"] },
+									{ "count": 1, "modules": ["BrailleModule"] },
+									{ "count": 2, "modules": ["britishSlang"] },
+									{ "count": 1, "modules": ["TheBulbModule"] },
+									{ "count": 1, "modules": ["ColoredSquaresModule"] },
+									{ "count": 1, "modules": ["ColoredSwitchesModule"] },
+									{ "count": 1, "modules": ["CoordinatesModule"] },
+									{ "count": 1, "modules": ["CursedDoubleOhModule"] },
+									{ "count": 1, "modules": ["DecoloredSquaresModule"] },
+									{ "count": 1, "modules": ["DiscoloredSquaresModule"] },
+									{ "count": 1, "modules": ["disorderedKeys"] },
+									{ "count": 1, "modules": ["factoryMaze"] },
+									{ "count": 1, "modules": ["forgetEnigma"] },
+									{ "count": 1, "modules": ["HexiEvilFMN"] },
+									{ "count": 1, "modules": ["MemoryV2"] },
+									{ "count": 1, "modules": ["forgetThemAll"] },
+									{ "count": 1, "modules": ["forgetThis"] },
+									{ "count": 1, "modules": ["GameOfLifeCruel"] },
+									{ "count": 1, "modules": ["HogwartsModule"] },
+									{ "count": 1, "modules": ["horribleMemory"] },
+									{ "count": 1, "modules": ["KudosudokuModule"] },
+									{ "count": 1, "modules": ["MadMemory"] },
+									{ "count": 1, "modules": ["MazeScrambler"] },
+									{ "count": 2, "modules": ["Memory"] },
+									{ "count": 1, "modules": ["misorderedKeys"] },
+									{ "count": 1, "modules": ["ModuleMaze"] },
+									{ "count": 1, "modules": ["MouseInTheMaze"] },
+									{ "count": 1, "modules": ["orderedKeys"] },
+									{ "count": 2, "modules": ["OrientationCube"] },
+									{ "count": 1, "modules": ["spwizPerspectivePegs"] },
+									{ "count": 1, "modules": ["PointOfOrderModule"] },
+									{ "count": 1, "modules": ["PointOfOrderModule"] },
+									{ "count": 1, "modules": ["PolyhedralMazeModule"] },
+									{ "count": 1, "modules": ["quizBuzz"] },
+									{ "count": 1, "modules": ["recordedKeys"] },
+									{ "count": 1, "modules": ["reorderedKeys"] },
+									{ "count": 1, "modules": ["simonScrambles"] },
+									{ "count": 1, "modules": ["SimonSingsModule"] },
+									{ "count": 1, "modules": ["SkewedSlotsModule"] },
+									{ "count": 1, "modules": ["sonic"] },
+									{ "count": 2, "modules": ["SouvenirModule"] },
+									{ "count": 1, "modules": ["switchModule"] },
+									{ "count": 1, "modules": ["SymbolCycleModule"] },
+									{ "count": 1, "modules": ["tapCode"] },
+									{ "count": 2, "modules": ["TurnTheKeyAdvanced"] },
+									{ "count": 1, "modules": ["TwoBits"] },
+									{ "count": 1, "modules": ["unorderedKeys"] },
+									{ "count": 1, "modules": ["ZooModule"] }
+								],
+								"modules": 54,
+								"strikes": 8,
+								"widgets": 6
+							},
+							"where": { "id": 14713 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 751,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "9563",
+			"name": "Try Not To Forget",
+			"action": "update",
+			"timestamp": "2024-10-24T19:30:33.707Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 6300,
+								"pools": [
+									{ "count": 1, "modules": ["MistakeModule"] },
+									{ "count": 1, "modules": ["borderedKeys"] },
+									{ "count": 1, "modules": ["BrailleModule"] },
+									{ "count": 2, "modules": ["britishSlang"] },
+									{ "count": 1, "modules": ["TheBulbModule"] },
+									{ "count": 1, "modules": ["ColoredSquaresModule"] },
+									{ "count": 1, "modules": ["ColoredSwitchesModule"] },
+									{ "count": 1, "modules": ["CoordinatesModule"] },
+									{ "count": 1, "modules": ["CursedDoubleOhModule"] },
+									{ "count": 1, "modules": ["DecoloredSquaresModule"] },
+									{ "count": 1, "modules": ["DiscoloredSquaresModule"] },
+									{ "count": 1, "modules": ["disorderedKeys"] },
+									{ "count": 1, "modules": ["factoryMaze"] },
+									{ "count": 1, "modules": ["forgetEnigma"] },
+									{ "count": 1, "modules": ["HexiEvilFMN"] },
+									{ "count": 1, "modules": ["MemoryV2"] },
+									{ "count": 1, "modules": ["forgetThemAll"] },
+									{ "count": 1, "modules": ["forgetThis"] },
+									{ "count": 1, "modules": ["GameOfLifeCruel"] },
+									{ "count": 1, "modules": ["HogwartsModule"] },
+									{ "count": 1, "modules": ["horribleMemory"] },
+									{ "count": 1, "modules": ["KudosudokuModule"] },
+									{ "count": 1, "modules": ["MadMemory"] },
+									{ "count": 1, "modules": ["MazeScrambler"] },
+									{ "count": 2, "modules": ["Memory"] },
+									{ "count": 1, "modules": ["misorderedKeys"] },
+									{ "count": 1, "modules": ["ModuleMaze"] },
+									{ "count": 1, "modules": ["MouseInTheMaze"] },
+									{ "count": 1, "modules": ["orderedKeys"] },
+									{ "count": 2, "modules": ["OrientationCube"] },
+									{ "count": 1, "modules": ["spwizPerspectivePegs"] },
+									{ "count": 2, "modules": ["PointOfOrderModule"] },
+									{ "count": 1, "modules": ["PolyhedralMazeModule"] },
+									{ "count": 1, "modules": ["quizBuzz"] },
+									{ "count": 1, "modules": ["recordedKeys"] },
+									{ "count": 1, "modules": ["reorderedKeys"] },
+									{ "count": 1, "modules": ["simonScrambles"] },
+									{ "count": 1, "modules": ["SimonSingsModule"] },
+									{ "count": 1, "modules": ["SkewedSlotsModule"] },
+									{ "count": 1, "modules": ["sonic"] },
+									{ "count": 2, "modules": ["SouvenirModule"] },
+									{ "count": 1, "modules": ["switchModule"] },
+									{ "count": 1, "modules": ["SymbolCycleModule"] },
+									{ "count": 1, "modules": ["tapCode"] },
+									{ "count": 2, "modules": ["TurnTheKeyAdvanced"] },
+									{ "count": 1, "modules": ["TwoBits"] },
+									{ "count": 1, "modules": ["unorderedKeys"] },
+									{ "count": 1, "modules": ["ZooModule"] }
+								],
+								"modules": 54,
+								"strikes": 8,
+								"widgets": 6
+							},
+							"where": { "id": 14713 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 752,
+			"userId": "337934133751840769",
+			"model": "Completion",
+			"recordId": "60640",
+			"name": "Try Not To Forget||Benjamin, Bianca, Burniel",
+			"action": "create",
+			"timestamp": "2024-10-24T21:54:54.380Z"
+		},
+		{
+			"id": 753,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60641",
+			"name": "17 Again||Termet, c12",
+			"action": "create",
+			"timestamp": "2024-10-25T12:46:12.007Z"
+		},
+		{
+			"id": 754,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60642",
+			"name": "Oompa Loompa Boon Poppycock||Termet",
+			"action": "create",
+			"timestamp": "2024-10-25T18:24:17.940Z"
+		},
+		{
+			"id": 755,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60643",
+			"name": "Boss Module Endurance||denial140",
+			"action": "create",
+			"timestamp": "2024-10-25T22:42:59.584Z"
+		},
+		{
+			"id": 756,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60644",
+			"name": "Divorce Papers: A Bored Ape Odyssey||Sierra",
+			"action": "create",
+			"timestamp": "2024-10-25T23:05:07.623Z"
+		},
+		{
+			"id": 757,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60645",
+			"name": "Centurion||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-10-26T03:50:06.061Z"
+		},
+		{
+			"id": 758,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10762",
+			"name": "Baka, Baka, Baka",
+			"action": "update",
+			"timestamp": "2024-10-26T09:10:05.616Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=dadc6ed0a6dc0bc4632bc3a126755425156ce5de" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=494bf8101e279c39148274c98678ffb6774e957b" }
+		},
+		{
+			"id": 759,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10770",
+			"name": "Grind Don't Stop!",
+			"action": "update",
+			"timestamp": "2024-10-26T09:16:44.200Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 760,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10771",
+			"name": "Needy Troubles For TP (Endurance)",
+			"action": "update",
+			"timestamp": "2024-10-26T09:16:47.330Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 761,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10755",
+			"name": "The Elven Chronicles: Hero's Awakening",
+			"action": "update",
+			"timestamp": "2024-10-26T09:17:02.845Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 762,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10763",
+			"name": "NoT!: Niigo",
+			"action": "update",
+			"timestamp": "2024-10-26T09:17:05.083Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 763,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10764",
+			"name": "QN!: FCDT",
+			"action": "update",
+			"timestamp": "2024-10-26T09:17:07.194Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 764,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10765",
+			"name": "Nothing To Spare: Pressured To Fail",
+			"action": "update",
+			"timestamp": "2024-10-26T09:17:10.126Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 765,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10767",
+			"name": "Mazemaster Endurance",
+			"action": "update",
+			"timestamp": "2024-10-26T09:17:12.665Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 766,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10746",
+			"name": "Orange",
+			"action": "update",
+			"timestamp": "2024-10-26T09:45:52.268Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=185ca24c00668e932574b0c9b3fa2f9340c02134" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 6000,
+							"pools": [
+								{ "count": 1, "modules": ["spwizAdventureGame"] },
+								{ "count": 1, "modules": ["boolMaze"] },
+								{ "count": 1, "modules": ["KritConnectionDev"] },
+								{ "count": 1, "modules": ["jackOLantern"] },
+								{ "count": 1, "modules": ["MysticSquareModule"] },
+								{ "count": 1, "modules": ["orangeArrowsModule"] },
+								{ "count": 1, "modules": ["turtleRobot"] },
+								{ "count": 1, "modules": ["Morse"] },
+								{ "count": 1, "modules": ["orangeCipher"] },
+								{ "count": 1, "modules": ["mechanusCipher"] },
+								{ "count": 1, "modules": ["QuoteCrazyTalkEndQuote"] },
+								{ "count": 1, "modules": ["placeholderTalk"] },
+								{ "count": 1, "modules": ["NotMorseCode"] },
+								{ "count": 1, "modules": ["GuessWho"] },
+								{ "count": 1, "modules": ["KritLockpickMaze"] },
+								{ "count": 1, "modules": ["boneAppleTea"] },
+								{ "count": 1, "modules": ["strikeSolve"] },
+								{ "count": 1, "modules": ["beans"] },
+								{ "count": 1, "modules": ["bigBean"] },
+								{ "count": 1, "modules": ["xelKeystrokes"] },
+								{ "count": 1, "modules": ["congkakMQEktane1"] },
+								{ "count": 1, "modules": ["orangeHexabuttons"] },
+								{ "count": 1, "modules": ["alteranTrail"] },
+								{ "count": 1, "modules": ["meteor"] },
+								{ "count": 1, "modules": ["TheArena"] },
+								{ "count": 1, "modules": ["matchingMorse"] },
+								{ "count": 1, "modules": ["letteredHexabuttons"] },
+								{ "count": 1, "modules": ["OrangeButtonModule"] },
+								{ "count": 1, "modules": ["TalkingPoints"] },
+								{ "count": 1, "modules": ["coralCipher"] },
+								{ "count": 1, "modules": ["orangebuttont"] },
+								{ "count": 1, "modules": ["MissionControl"] },
+								{ "count": 1, "modules": ["schulteTable"] },
+								{ "count": 1, "modules": ["Tether"] },
+								{ "count": 1, "modules": ["solveStrike"] },
+								{ "count": 1, "modules": ["TipToe"] },
+								{ "count": 1, "modules": ["AmberButtonModule"] },
+								{ "count": 1, "modules": ["KritHomework"] },
+								{ "count": 1, "modules": ["mazeCode"] },
+								{ "count": 1, "modules": ["GSWinningLine"] },
+								{ "count": 1, "modules": ["patternRecognition"] },
+								{ "count": 1, "modules": ["FlaminFinger"] },
+								{ "count": 1, "modules": ["NeedyBeer"] },
+								{ "count": 1, "modules": ["runonSentence"] },
+								{ "count": 1, "modules": ["ventilation"] },
+								{ "count": 1, "modules": ["rustGB"] },
+								{ "count": 1, "modules": ["mars"] }
+							],
+							"modules": 47,
+							"strikes": 5,
+							"widgets": 7
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=a86a178821d846c4faac5176344669aab0bf54fc"
+			}
+		},
+		{
+			"id": 767,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10779",
+			"name": "[[UPDATE]] Orange",
+			"action": "delete",
+			"timestamp": "2024-10-26T09:45:52.283Z",
+			"before": {
+				"id": 10779,
+				"name": "[[UPDATE]] Orange",
+				"notes": null,
+				"authors": ["eXish"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=a86a178821d846c4faac5176344669aab0bf54fc",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_eXishMissions_orange",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-10-19T19:12:06.806Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "208633883544125440",
+				"designedForTP": false,
+				"missionPackId": 419
+			}
+		},
+		{
+			"id": 768,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10591",
+			"name": "New Supersonic",
+			"action": "update",
+			"timestamp": "2024-10-26T09:47:34.793Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=1036272e20c48fb7c21b88280440a18c6c577347" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 5400,
+							"pools": [
+								{ "count": 3, "modules": ["widgetry"] },
+								{ "count": 1, "modules": ["combinationLock"] },
+								{ "count": 1, "modules": ["hexabutton"] },
+								{ "count": 1, "modules": ["theNumber"] },
+								{ "count": 1, "modules": ["BigCircle"] },
+								{ "count": 1, "modules": ["burgerAlarm"] },
+								{ "count": 1, "modules": ["MorseAMaze"] },
+								{ "count": 1, "modules": ["Astrological"] },
+								{ "count": 1, "modules": ["kookyKeypadModule"] },
+								{ "count": 1, "modules": ["R4YUncoloredSwitches"] },
+								{ "count": 1, "modules": ["sevenWires"] },
+								{ "count": 1, "modules": ["phones"] },
+								{ "count": 1, "modules": ["GSTellMeWhen"] },
+								{ "count": 1, "modules": ["objectShows"] },
+								{ "count": 1, "modules": ["colors_maximization", "digit_sum"] },
+								{ "count": 1, "modules": ["MafiaModule"] },
+								{ "count": 1, "modules": ["mineseeker"] },
+								{ "count": 1, "modules": ["smbh"] },
+								{ "count": 1, "modules": ["ultraDigitalRootModule"] },
+								{ "count": 1, "modules": ["charge", "space_traders"] },
+								{ "count": 1, "modules": ["subway", "handTurkey"] },
+								{ "count": 1, "modules": ["Skewers"] },
+								{ "count": 1, "modules": ["TheDials"] },
+								{ "count": 2, "modules": ["Netherite"] },
+								{ "count": 3, "modules": ["burnt"] },
+								{ "count": 1, "modules": ["RGBSequences"] },
+								{ "count": 1, "modules": ["GSAccessCodes"] },
+								{ "count": 1, "modules": ["GSTernaryTiles"] },
+								{ "count": 1, "modules": ["KritConnectionDev"] },
+								{ "count": 1, "modules": ["unrelatedAnagrams"] },
+								{ "count": 1, "modules": ["cooking"] },
+								{ "count": 1, "modules": ["Sink"] },
+								{ "count": 1, "modules": ["PerplexingWiresModule"] },
+								{ "count": 1, "modules": ["GL_nokiaModule"] },
+								{ "count": 3, "modules": ["macroMemory"] },
+								{ "count": 1, "modules": ["templatemodule", "encryptcore"] },
+								{ "count": 1, "modules": ["BlackHoleModule"] },
+								{ "count": 1, "modules": ["WhiteHoleModule"] },
+								{ "count": 1, "modules": ["CuttingOrder"] },
+								{ "count": 1, "modules": ["antichamber"] }
+							],
+							"modules": 47,
+							"strikes": 6,
+							"widgets": 0
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=7986116413708299f20fde3f91545a4ed4e0af7a"
+			}
+		},
+		{
+			"id": 769,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10780",
+			"name": "[[UPDATE]] New Supersonic",
+			"action": "delete",
+			"timestamp": "2024-10-26T09:47:34.806Z",
+			"before": {
+				"id": 10780,
+				"name": "[[UPDATE]] New Supersonic",
+				"notes": null,
+				"authors": ["eXish"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=7986116413708299f20fde3f91545a4ed4e0af7a",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_eXishMissions_newsupersonic",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-10-19T19:22:54.987Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "208633883544125440",
+				"designedForTP": false,
+				"missionPackId": 419
+			}
+		},
+		{
+			"id": 770,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10646",
+			"name": "Triple Trouble",
+			"action": "update",
+			"timestamp": "2024-10-26T09:49:01.310Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=66477b7c69f4bcb0cfb16b22ca7c7a9519b1cb8f" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 1380,
+							"pools": [
+								{ "count": 1, "modules": ["GSBottomGear"] },
+								{ "count": 1, "modules": ["GSTellMeWhen"] },
+								{ "count": 1, "modules": ["sqlBasic"] },
+								{ "count": 1, "modules": ["MahjongQuizEasy"] },
+								{ "count": 1, "modules": ["BigCircle"] },
+								{ "count": 1, "modules": ["pwGenerator"] },
+								{ "count": 1, "modules": ["xelDcode"] },
+								{ "count": 1, "modules": ["digitalDials"] },
+								{ "count": 1, "modules": ["HiraganaModule"] },
+								{ "count": 1, "modules": ["countdown"] },
+								{ "count": 1, "modules": ["WhosOnFirst"] },
+								{ "count": 1, "modules": ["GSCatchMeIfYouCan"] },
+								{ "count": 1, "modules": ["YellowHuffmanCipherModule"] },
+								{ "count": 1, "modules": ["voltaicMorseModule"] },
+								{ "count": 1, "modules": ["hexOrbits"] },
+								{ "count": 1, "modules": ["Coinage"] },
+								{ "count": 1, "modules": ["runeMatchI"] }
+							],
+							"modules": 17,
+							"strikes": 4,
+							"widgets": 5
+						},
+						{
+							"time": 2040,
+							"pools": [
+								{ "count": 1, "modules": ["GSBottomGear2"] },
+								{ "count": 1, "modules": ["GSTellMeWhy"] },
+								{ "count": 1, "modules": ["sqlEvil"] },
+								{ "count": 1, "modules": ["MahjongQuizHard"] },
+								{ "count": 1, "modules": ["midCircle"] },
+								{ "count": 1, "modules": ["pwDestroyer"] },
+								{ "count": 1, "modules": ["xelDcrypt"] },
+								{ "count": 1, "modules": ["colorfulDials"] },
+								{ "count": 1, "modules": ["KatakanaModule"] },
+								{ "count": 1, "modules": ["cruelCountdown"] },
+								{ "count": 1, "modules": ["WhatsOnSecond"] },
+								{ "count": 1, "modules": ["GSWinningLine"] },
+								{ "count": 1, "modules": ["BlueHuffmanCipherModule"] },
+								{ "count": 1, "modules": ["triskaideka"] },
+								{ "count": 1, "modules": ["hexNull"] },
+								{ "count": 1, "modules": ["BoozleageModule"] },
+								{ "count": 1, "modules": ["runeMatchII"] }
+							],
+							"modules": 17,
+							"strikes": 4,
+							"widgets": 5
+						},
+						{
+							"time": 2880,
+							"pools": [
+								{ "count": 1, "modules": ["GSBottomGear3"] },
+								{ "count": 1, "modules": ["GSTellMeWhere"] },
+								{ "count": 1, "modules": ["sqlCruel"] },
+								{ "count": 1, "modules": ["MahjongQuizScrambled"] },
+								{ "count": 1, "modules": ["smallCircle"] },
+								{ "count": 1, "modules": ["pwMutilatorEX"] },
+								{ "count": 1, "modules": ["xelDcipher"] },
+								{ "count": 1, "modules": ["scalarDials"] },
+								{ "count": 1, "modules": ["ShiritoriModule"] },
+								{ "count": 1, "modules": ["ChaoticCountdownModule"] },
+								{ "count": 1, "modules": ["ThirdBase"] },
+								{ "count": 1, "modules": ["GSSatNav"] },
+								{ "count": 1, "modules": ["RedHuffmanCipherModule"] },
+								{ "count": 1, "modules": ["bustedPasswordModule"] },
+								{ "count": 1, "modules": ["hexOS"] },
+								{ "count": 1, "modules": ["buttonageModule"] },
+								{ "count": 1, "modules": ["runeMatchIII"] }
+							],
+							"modules": 17,
+							"strikes": 4,
+							"widgets": 5
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=76f6ee3a667722ab9672de9723879ee901712c43"
+			}
+		},
+		{
+			"id": 771,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10781",
+			"name": "[[UPDATE]] Triple Trouble",
+			"action": "delete",
+			"timestamp": "2024-10-26T09:49:01.324Z",
+			"before": {
+				"id": 10781,
+				"name": "[[UPDATE]] Triple Trouble",
+				"notes": null,
+				"authors": ["Axodeau"],
+				"factory": "Sequence",
+				"logfile": "https://ktane.timwi.de/lfa#file=76f6ee3a667722ab9672de9723879ee901712c43",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_AxoRandoMission_Triple Trouble",
+				"timeMode": "Local",
+				"verified": false,
+				"dateAdded": "2024-10-20T19:34:14.638Z",
+				"inGameName": null,
+				"strikeMode": "Local",
+				"uploadedBy": "832703757615497298",
+				"designedForTP": false,
+				"missionPackId": 404
+			}
+		},
+		{
+			"id": 772,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10708",
+			"name": "Canonically Diabolical",
+			"action": "update",
+			"timestamp": "2024-10-26T09:49:53.765Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=fbbfcfd550179f69a61d9cdfb2a0d5529e7d100d" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 5640,
+							"pools": [
+								{ "count": 1, "modules": ["WireSequenceSequence"] },
+								{ "count": 1, "modules": ["colorBlindness"] },
+								{ "count": 1, "modules": ["q&a"] },
+								{ "count": 1, "modules": ["ColorSymbolicInterpretationModule"] },
+								{ "count": 1, "modules": ["PurgatorysNameList"] },
+								{ "count": 1, "modules": ["MultiverseHotline"] },
+								{ "count": 1, "modules": ["solarReorder"] },
+								{ "count": 1, "modules": ["GSWinningLine"] },
+								{ "count": 1, "modules": ["whosSimon"] },
+								{ "count": 1, "modules": ["PapyrusTiles"] },
+								{ "count": 1, "modules": ["wireTesting"] },
+								{ "count": 1, "modules": ["colorPong"] },
+								{ "count": 1, "modules": ["GSCruelDialTrial"] },
+								{ "count": 1, "modules": ["GTACheats"] },
+								{ "count": 1, "modules": ["simonServes"] },
+								{ "count": 1, "modules": ["captchaTheFlag"] },
+								{ "count": 1, "modules": ["Patterns"] },
+								{ "count": 1, "modules": ["reflexFactoryModule"] },
+								{ "count": 1, "modules": ["NotSymbolicPasswordModule"] },
+								{ "count": 1, "modules": ["atlantis"] },
+								{ "count": 1, "modules": ["LongWords"] },
+								{ "count": 1, "modules": ["blankCard"] },
+								{ "count": 1, "modules": ["switchPlacement"] },
+								{ "count": 1, "modules": ["CyanButtonModule"] },
+								{ "count": 1, "modules": ["gendercipher"] },
+								{ "count": 1, "modules": ["SimonSignalsModule"] },
+								{ "count": 1, "modules": ["mwisort"] },
+								{ "count": 1, "modules": ["MaritimeSemaphoreModule"] },
+								{ "count": 1, "modules": ["connectFourModule"] },
+								{ "count": 1, "modules": ["trunic"] },
+								{ "count": 1, "modules": ["solveStrike"] },
+								{ "count": 1, "modules": ["Linq"] },
+								{ "count": 1, "modules": ["beanSprouts"] },
+								{ "count": 1, "modules": ["doubleScreenModule"] },
+								{ "count": 1, "modules": ["MusicalTransposition"] },
+								{ "count": 1, "modules": ["simonSteps"] },
+								{ "count": 1, "modules": ["memoryPoker"] },
+								{ "count": 1, "modules": ["wackGameOfLife"] },
+								{ "count": 1, "modules": ["sixten"] },
+								{ "count": 1, "modules": ["touchTransmission"] },
+								{ "count": 1, "modules": ["threeLEDsModule"] },
+								{ "count": 1, "modules": ["swish"] },
+								{ "count": 1, "modules": ["colouredCylinder"] },
+								{ "count": 1, "modules": ["binaryGrid"] },
+								{ "count": 1, "modules": ["AlienModule"] },
+								{ "count": 1, "modules": ["SetTheory"] },
+								{ "count": 1, "modules": ["TheDials"] }
+							],
+							"modules": 47,
+							"strikes": 5,
+							"widgets": 5
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=d107d5f8ef60a3af22c7c868684d69370b92d6bc"
+			}
+		},
+		{
+			"id": 773,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10782",
+			"name": "[[UPDATE]] Canonically Diabolical",
+			"action": "delete",
+			"timestamp": "2024-10-26T09:49:53.778Z",
+			"before": {
+				"id": 10782,
+				"name": "[[UPDATE]] Canonically Diabolical",
+				"notes": null,
+				"authors": ["Axodeau"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=d107d5f8ef60a3af22c7c868684d69370b92d6bc",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_AxoRandoMission_Canonically Diabolical",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-10-20T22:05:47.627Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "832703757615497298",
+				"designedForTP": false,
+				"missionPackId": 404
+			}
+		},
+		{
+			"id": 774,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10685",
+			"name": "How do you keep an idiot busy?",
+			"action": "update",
+			"timestamp": "2024-10-26T09:50:17.164Z",
+			"before": {
+				"logfile": "https://ktane.timwi.de/lfa#file=00d97df92e536b92c56b15aea5925828666d3fff",
+				"inGameId": "mod_blvd_idiot, DisplayNameTerm: mod/blvd_idiot_DisplayName"
+			},
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 13800,
+							"pools": [
+								{ "count": 1, "modules": ["cipherMachine"] },
+								{ "count": 1, "modules": ["tetrisSprint"] },
+								{ "count": 1, "modules": ["hexaterminals"] },
+								{ "count": 1, "modules": ["piecePositioning"] },
+								{ "count": 1, "modules": ["rgbChess"] },
+								{ "count": 1, "modules": ["FlaminFinger"] },
+								{ "count": 1, "modules": ["swish"] },
+								{ "count": 1, "modules": ["GSNumberCruncher"] },
+								{ "count": 1, "modules": ["ThreeDimensionalChess"] },
+								{ "count": 1, "modules": ["numbrix"] },
+								{ "count": 1, "modules": ["rasterPrime"] },
+								{ "count": 1, "modules": ["theMidnightMotoristModule"] },
+								{ "count": 1, "modules": ["setConnections"] },
+								{ "count": 1, "modules": ["markscript"] },
+								{ "count": 1, "modules": ["baseOn"] },
+								{ "count": 1, "modules": ["SCP2719"] },
+								{ "count": 1, "modules": ["ironLung"] },
+								{ "count": 1, "modules": ["manualMalady"] },
+								{ "count": 1, "modules": ["ChaoticCountdownModule"] },
+								{ "count": 1, "modules": ["DominosaModule"] },
+								{ "count": 1, "modules": ["MahjongQuizScrambled"] },
+								{ "count": 1, "modules": ["CornflowerButtonModule"] },
+								{ "count": 1, "modules": ["finiteLoop"] },
+								{ "count": 1, "modules": ["ro"] },
+								{ "count": 1, "modules": ["fishing"] },
+								{ "count": 1, "modules": ["xo"] },
+								{ "count": 1, "modules": ["spillingPaint"] },
+								{ "count": 1, "modules": ["shashki"] },
+								{ "count": 1, "modules": ["flippingTriangles"] },
+								{ "count": 1, "modules": ["nonbinaryPuzzle"] },
+								{ "count": 1, "modules": ["2048"] },
+								{ "count": 1, "modules": ["squeeze"] },
+								{ "count": 1, "modules": ["anomia"] },
+								{ "count": 1, "modules": ["mischmodul"] },
+								{ "count": 1, "modules": ["factoringMaze"] },
+								{ "count": 1, "modules": ["1DChess"] },
+								{ "count": 1, "modules": ["oneLine"] },
+								{ "count": 1, "modules": ["RegularSudoku"] },
+								{ "count": 1, "modules": ["hexiomModule"] },
+								{ "count": 1, "modules": ["etchASketch"] },
+								{ "count": 1, "modules": ["ReportingAnomalies"] },
+								{ "count": 1, "modules": ["inupiaqNumerals"] },
+								{ "count": 2, "modules": ["metamem"] },
+								{ "count": 1, "modules": ["digisibility"] },
+								{ "count": 1, "modules": ["TheCalculator"] },
+								{ "count": 1, "modules": ["qkGnomishPuzzle"] },
+								{ "count": 1, "modules": ["ultimateTicTacToe"] },
+								{ "count": 1, "modules": ["Jailbreak"] },
+								{ "count": 1, "modules": ["fitIN"] },
+								{ "count": 1, "modules": ["kataMinecraftSurvival"] },
+								{ "count": 1, "modules": ["linesOfCode"] },
+								{ "count": 1, "modules": ["loopover"] },
+								{ "count": 1, "modules": ["matchematics"] },
+								{ "count": 1, "modules": ["TennisModule"] }
+							],
+							"modules": 55,
+							"strikes": 5,
+							"widgets": 5
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=0bdc53c76832f0bbf10b84ae3979fcd1cdbbc42d",
+				"inGameId": "mod_blvd_idiot"
+			}
+		},
+		{
+			"id": 775,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10784",
+			"name": "[[UPDATE]] How do you keep an idiot busy?",
+			"action": "delete",
+			"timestamp": "2024-10-26T09:50:17.179Z",
+			"before": {
+				"id": 10784,
+				"name": "[[UPDATE]] How do you keep an idiot busy?",
+				"notes": null,
+				"authors": ["BlvdBroken"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=0bdc53c76832f0bbf10b84ae3979fcd1cdbbc42d",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_blvd_idiot",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-10-22T22:40:30.340Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "832703757615497298",
+				"designedForTP": false,
+				"missionPackId": 538
+			}
+		},
+		{
+			"id": 776,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10754",
+			"name": "CT - Team",
+			"action": "delete",
+			"timestamp": "2024-10-26T09:55:08.102Z",
+			"before": {
+				"id": 10754,
+				"name": "CT - Team",
+				"notes": null,
+				"authors": ["Sean"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=2bf2156bc835bf975f16ec959e483cefe76982b0",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_cipherTurion_CT Team",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-09-29T11:20:30.530Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "96589122726014976",
+				"designedForTP": false,
+				"missionPackId": 613
+			}
+		},
+		{
+			"id": 777,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60618",
+			"name": "Nothing To Spare: Quickly Now!||Termet",
+			"action": "update",
+			"timestamp": "2024-10-26T09:58:31.081Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 778,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60619",
+			"name": "Undefined 47||Lyph",
+			"action": "update",
+			"timestamp": "2024-10-26T10:03:14.283Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 779,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60620",
+			"name": "Centurion||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-10-26T10:03:31.774Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 780,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60621",
+			"name": "Great Berate Practice||BladePL",
+			"action": "update",
+			"timestamp": "2024-10-26T10:04:06.068Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 781,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60622",
+			"name": "Intro to Modded KTANE||BladePL",
+			"action": "update",
+			"timestamp": "2024-10-26T10:05:26.037Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 782,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60623",
+			"name": "I Love Countdown!||Faith",
+			"action": "update",
+			"timestamp": "2024-10-26T10:06:10.618Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 783,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "56181",
+			"name": "47||Procyon",
+			"action": "update",
+			"timestamp": "2024-10-26T10:08:31.716Z",
+			"before": {
+				"time": 458,
+				"proofs": ["https://cdn.discordapp.com/attachments/306830460443426816/612376772977360916/image0.jpg"]
+			},
+			"after": {
+				"time": 877.41,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=bd6ae477492c02f2e29d1623eb5926be768cb4ba;bomb=NF1ZW6"
+				]
+			}
+		},
+		{
+			"id": 784,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60624",
+			"name": "47||Procyon",
+			"action": "delete",
+			"timestamp": "2024-10-26T10:08:31.724Z",
+			"before": {
+				"id": 60624,
+				"old": false,
+				"solo": false,
+				"team": ["Procyon"],
+				"time": 877.41,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=bd6ae477492c02f2e29d1623eb5926be768cb4ba;bomb=NF1ZW6"
+				],
+				"verified": false,
+				"dateAdded": "2024-10-22T00:26:27.416Z",
+				"missionId": 9843,
+				"uploadedBy": "123571941599608834"
+			}
+		},
+		{
+			"id": 785,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59166",
+			"name": "Dove||denial140",
+			"action": "update",
+			"timestamp": "2024-10-26T10:09:43.735Z",
+			"before": {
+				"time": 2307.7,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=f591ab79010d78f3e42ebf7b5ee05aab0dc6877a;bomb=2W7PI1"
+				]
+			},
+			"after": {
+				"time": 2972.95,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=69adb23bec2d2f3e962014d59cbe355255eccde1;bomb=C50EL6",
+					"https://youtu.be/lrqU5V73AjA"
+				]
+			}
+		},
+		{
+			"id": 786,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60625",
+			"name": "Dove||denial140",
+			"action": "delete",
+			"timestamp": "2024-10-26T10:09:43.743Z",
+			"before": {
+				"id": 60625,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 2972.95,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=69adb23bec2d2f3e962014d59cbe355255eccde1;bomb=C50EL6",
+					"https://youtu.be/lrqU5V73AjA"
+				],
+				"verified": false,
+				"dateAdded": "2024-10-22T04:14:01.905Z",
+				"missionId": 9497,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 787,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60626",
+			"name": "Sweet 16||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-10-26T10:09:57.167Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 788,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60627",
+			"name": "By Popular Demand||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-10-26T10:11:05.913Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 789,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60628",
+			"name": ":((=||c12, Termet, Danielstigman",
+			"action": "update",
+			"timestamp": "2024-10-26T10:13:13.454Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 790,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60629",
+			"name": "Sky's the Minimum||Sierra",
+			"action": "update",
+			"timestamp": "2024-10-26T10:14:58.717Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 791,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60620",
+			"name": "Centurion||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-10-26T10:22:39.165Z",
+			"before": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=27d003a8ab132d2e2c0fb942d99ac952773b99ef;bomb=JE8BK7"
+				]
+			},
+			"after": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=27d003a8ab132d2e2c0fb942d99ac952773b99ef;bomb=JE8BK7",
+					"https://www.youtube.com/watch?v=jEPtXsnJSvw"
+				]
+			}
+		},
+		{
+			"id": 792,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60626",
+			"name": "Sweet 16||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-10-26T10:24:16.504Z",
+			"before": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=4533a324b8aa31de471ae8ad3d559e4419d135c6;bomb=VE9HR5"
+				]
+			},
+			"after": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=4533a324b8aa31de471ae8ad3d559e4419d135c6;bomb=VE9HR5",
+					"https://www.youtube.com/watch?v=QXbOMvSWmqY"
+				]
+			}
+		},
+		{
+			"id": 793,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10699",
+			"name": "Module Marathon",
+			"action": "update",
+			"timestamp": "2024-10-26T10:27:02.507Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["BigButton"] },
+									{ "count": 1, "modules": ["Venn"] },
+									{ "count": 1, "modules": ["Emoji Math"] },
+									{ "count": 1, "modules": ["Keypad"] },
+									{ "count": 1, "modules": ["Maze"] },
+									{ "count": 1, "modules": ["Password"] },
+									{ "count": 1, "modules": ["PianoKeys"] },
+									{ "count": 1, "modules": ["Semaphore"] },
+									{ "count": 1, "modules": ["switchModule"] },
+									{ "count": 1, "modules": ["Wires"] },
+									{ "count": 1, "modules": ["WordScrambleModule"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14602 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["alphabet"] },
+									{ "count": 1, "modules": ["spwizAstrology"] },
+									{ "count": 1, "modules": ["TheBulbModule"] },
+									{ "count": 1, "modules": ["CaesarCipherModule"] },
+									{ "count": 1, "modules": ["ChessModule"] },
+									{ "count": 1, "modules": ["graphModule"] },
+									{ "count": 1, "modules": ["CrazyTalk"] },
+									{ "count": 1, "modules": ["FollowTheLeaderModule"] },
+									{ "count": 1, "modules": ["LetterKeys"] },
+									{ "count": 1, "modules": ["murder"] },
+									{ "count": 1, "modules": ["KeypadV2"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14603 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["BlindAlleyModule"] },
+									{ "count": 1, "modules": ["ColoredSquaresModule"] },
+									{ "count": 1, "modules": ["complicatedButtonsModule"] },
+									{ "count": 1, "modules": ["DoubleOhModule"] },
+									{ "count": 1, "modules": ["LightCycleModule"] },
+									{ "count": 1, "modules": ["RockPaperScissorsLizardSpockModule"] },
+									{ "count": 1, "modules": ["ButtonV2"] },
+									{ "count": 1, "modules": ["symbolicPasswordModule"] },
+									{ "count": 1, "modules": ["TextField"] },
+									{ "count": 1, "modules": ["WirePlacementModule"] },
+									{ "count": 1, "modules": ["WordSearchModule"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14604 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["BitOps"] },
+									{ "count": 1, "modules": ["ChordQualities"] },
+									{ "count": 1, "modules": ["TheClockModule"] },
+									{ "count": 1, "modules": ["colormath"] },
+									{ "count": 1, "modules": ["CreationModule"] },
+									{ "count": 1, "modules": ["fastMath"] },
+									{ "count": 1, "modules": ["fizzBuzzModule"] },
+									{ "count": 1, "modules": ["neutralization"] },
+									{ "count": 1, "modules": ["MusicRhythms"] },
+									{ "count": 1, "modules": ["RubiksCubeModule"] },
+									{ "count": 1, "modules": ["webDesign"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14605 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["BinaryLeds"] },
+									{ "count": 1, "modules": ["booleanVennModule"] },
+									{ "count": 1, "modules": ["ColorMorseModule"] },
+									{ "count": 1, "modules": ["GridlockModule"] },
+									{ "count": 1, "modules": ["Mastermind Simple"] },
+									{ "count": 1, "modules": ["MinesweeperModule"] },
+									{ "count": 1, "modules": ["PointOfOrderModule"] },
+									{ "count": 1, "modules": ["screw"] },
+									{ "count": 1, "modules": ["XRayModule"] },
+									{ "count": 1, "modules": ["YahtzeeModule"] },
+									{ "count": 1, "modules": ["ZooModule"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14606 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["BrailleModule"] },
+									{ "count": 1, "modules": ["Color Generator"] },
+									{ "count": 1, "modules": ["ColoredSwitchesModule"] },
+									{ "count": 1, "modules": ["ExtendedPassword"] },
+									{ "count": 1, "modules": ["FestivePianoKeys"] },
+									{ "count": 1, "modules": ["FlagsModule"] },
+									{ "count": 1, "modules": ["NonogramModule"] },
+									{ "count": 1, "modules": ["Painting"] },
+									{ "count": 1, "modules": ["PerplexingWiresModule"] },
+									{ "count": 1, "modules": ["SetModule"] },
+									{ "count": 1, "modules": ["timezone"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14607 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["Backgrounds"] },
+									{ "count": 1, "modules": ["errorCodes"] },
+									{ "count": 1, "modules": ["identityParade"] },
+									{ "count": 1, "modules": ["ledGrid"] },
+									{ "count": 1, "modules": ["mashematics"] },
+									{ "count": 1, "modules": ["mortalKombat"] },
+									{ "count": 1, "modules": ["pieModule"] },
+									{ "count": 1, "modules": ["poetry"] },
+									{ "count": 1, "modules": ["radiator"] },
+									{ "count": 1, "modules": ["Sink"] },
+									{ "count": 1, "modules": ["visual_impairment"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14608 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["calendar"] },
+									{ "count": 1, "modules": ["theCodeModule"] },
+									{ "count": 1, "modules": ["complexKeypad"] },
+									{ "count": 1, "modules": ["digitalRoot"] },
+									{ "count": 1, "modules": ["graffitiNumbers"] },
+									{ "count": 1, "modules": ["GridMatching"] },
+									{ "count": 1, "modules": ["MazeScrambler"] },
+									{ "count": 1, "modules": ["MorseWar"] },
+									{ "count": 1, "modules": ["Playfair"] },
+									{ "count": 1, "modules": ["tapCode"] },
+									{ "count": 1, "modules": ["USA"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14609 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["boggle"] },
+									{ "count": 1, "modules": ["britishSlang"] },
+									{ "count": 1, "modules": ["characterShift"] },
+									{ "count": 1, "modules": ["doubleColor"] },
+									{ "count": 1, "modules": ["flashingLights"] },
+									{ "count": 1, "modules": ["KritHomework"] },
+									{ "count": 1, "modules": ["numberCipher"] },
+									{ "count": 1, "modules": ["reverseMorse"] },
+									{ "count": 1, "modules": ["shikaku"] },
+									{ "count": 1, "modules": ["BigSwitch"] },
+									{ "count": 1, "modules": ["UncoloredSquaresModule"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14610 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["CrackboxModule"] },
+									{ "count": 1, "modules": ["TheDigitModule"] },
+									{ "count": 1, "modules": ["dominoes"] },
+									{ "count": 1, "modules": ["hangover"] },
+									{ "count": 1, "modules": ["instructions"] },
+									{ "count": 1, "modules": ["modulo"] },
+									{ "count": 1, "modules": ["KritRadio"] },
+									{ "count": 1, "modules": ["skinnyWires"] },
+									{ "count": 1, "modules": ["spinningButtons"] },
+									{ "count": 1, "modules": ["streetFighter"] },
+									{ "count": 1, "modules": ["tWords"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14611 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["digitalCipher"] },
+									{ "count": 1, "modules": ["groceryStore"] },
+									{ "count": 1, "modules": ["homophones"] },
+									{ "count": 1, "modules": ["lgndLEDMath"] },
+									{ "count": 1, "modules": ["megaMan2"] },
+									{ "count": 1, "modules": ["Numbers"] },
+									{ "count": 1, "modules": ["Questionmark"] },
+									{ "count": 1, "modules": ["simonScrambles"] },
+									{ "count": 1, "modules": ["stackem"] },
+									{ "count": 1, "modules": ["VaricoloredSquaresModule"] },
+									{ "count": 1, "modules": ["lgndZoni"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14612 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["MistakeModule"] },
+									{ "count": 1, "modules": ["babaIsWho"] },
+									{ "count": 1, "modules": ["theBlock"] },
+									{ "count": 1, "modules": ["daylightDirections"] },
+									{ "count": 1, "modules": ["giantsDrink"] },
+									{ "count": 1, "modules": ["purpleArrowsModule"] },
+									{ "count": 1, "modules": ["redArrowsModule"] },
+									{ "count": 1, "modules": ["riskyWires"] },
+									{ "count": 1, "modules": ["stainedGlass"] },
+									{ "count": 1, "modules": ["symbolicColouring"] },
+									{ "count": 1, "modules": ["unorderedKeys"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14613 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["boneAppleTea"] },
+									{ "count": 1, "modules": ["caesarCycle"] },
+									{ "count": 1, "modules": ["faultyDigitalRootModule"] },
+									{ "count": 1, "modules": ["FlashMemory"] },
+									{ "count": 1, "modules": ["fruits"] },
+									{ "count": 1, "modules": ["luckyDice"] },
+									{ "count": 1, "modules": ["matchematics"] },
+									{ "count": 1, "modules": ["pictionaryModule"] },
+									{ "count": 1, "modules": ["PrimeChecker"] },
+									{ "count": 1, "modules": ["theRule"] },
+									{ "count": 1, "modules": ["ksmTetraVex"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14614 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["nonverbalSimon"] },
+									{ "count": 1, "modules": ["chineseCounting"] },
+									{ "count": 1, "modules": ["colorAddition"] },
+									{ "count": 1, "modules": ["coloredMaze"] },
+									{ "count": 1, "modules": ["divisibleNumbers"] },
+									{ "count": 1, "modules": ["bigegg"] },
+									{ "count": 1, "modules": ["EncryptedDice"] },
+									{ "count": 1, "modules": ["ingredients"] },
+									{ "count": 1, "modules": ["KanjiModule"] },
+									{ "count": 1, "modules": ["NandMs"] },
+									{ "count": 1, "modules": ["spellingBee"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14615 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["punctuationMarks"] },
+									{ "count": 1, "modules": ["OneDimensionalMaze"] },
+									{ "count": 1, "modules": ["gatekeeper"] },
+									{ "count": 1, "modules": ["LightBulbs"] },
+									{ "count": 1, "modules": ["NotMemory"] },
+									{ "count": 1, "modules": ["NotSimaze"] },
+									{ "count": 1, "modules": ["NotWiresword"] },
+									{ "count": 1, "modules": ["sequencesModule"] },
+									{ "count": 1, "modules": ["shellGame"] },
+									{ "count": 1, "modules": ["topsyTurvy"] },
+									{ "count": 1, "modules": ["VCRCS"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14616 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["BasicMorse"] },
+									{ "count": 1, "modules": ["buttonOrder"] },
+									{ "count": 1, "modules": ["caesarsMaths"] },
+									{ "count": 1, "modules": ["TheCalculator"] },
+									{ "count": 1, "modules": ["theDuck"] },
+									{ "count": 1, "modules": ["JadenSmithTalk"] },
+									{ "count": 1, "modules": ["JustNumbersModule"] },
+									{ "count": 1, "modules": ["ModuleRick"] },
+									{ "count": 1, "modules": ["stars"] },
+									{ "count": 1, "modules": ["StockImages"] },
+									{ "count": 1, "modules": ["strikeSolve"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14617 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["breaktime"] },
+									{ "count": 1, "modules": ["colorNumbers"] },
+									{ "count": 1, "modules": ["colorCycleButton"] },
+									{ "count": 1, "modules": ["ColoredButtons"] },
+									{ "count": 1, "modules": ["digitalClock"] },
+									{ "count": 1, "modules": ["evenOrOdd"] },
+									{ "count": 1, "modules": ["HigherOrLower"] },
+									{ "count": 1, "modules": ["mastermindRestricted"] },
+									{ "count": 1, "modules": ["mindlock"] },
+									{ "count": 1, "modules": ["PixelArt"] },
+									{ "count": 1, "modules": ["workingTitle"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14618 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["AtbashCipher"] },
+									{ "count": 1, "modules": ["bigBean"] },
+									{ "count": 1, "modules": ["colouredArrowsModule"] },
+									{ "count": 1, "modules": ["CosmicModule"] },
+									{ "count": 1, "modules": ["doubleScreenModule"] },
+									{ "count": 1, "modules": ["numberedButtonsModule"] },
+									{ "count": 1, "modules": ["pressTheShape"] },
+									{ "count": 1, "modules": ["redHexabuttons"] },
+									{ "count": 1, "modules": ["standardButtonMasher"] },
+									{ "count": 1, "modules": ["xelSymmetriesOfASquare"] },
+									{ "count": 1, "modules": ["valuedKeysModule"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14619 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["TDSAmogus"] },
+									{ "count": 1, "modules": ["BinaryButtons"] },
+									{ "count": 1, "modules": ["CodeCracker"] },
+									{ "count": 1, "modules": ["GSDirectingButtons"] },
+									{ "count": 1, "modules": ["functionalMapping"] },
+									{ "count": 1, "modules": ["CaptchaModule"] },
+									{ "count": 1, "modules": ["Indentation"] },
+									{ "count": 1, "modules": ["mischmodul"] },
+									{ "count": 1, "modules": ["newline"] },
+									{ "count": 1, "modules": ["numpath"] },
+									{ "count": 1, "modules": ["TDSNya"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14620 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["blueWhale"] },
+									{ "count": 1, "modules": ["CactusPConundrum"] },
+									{ "count": 1, "modules": ["flippingTriangles"] },
+									{ "count": 1, "modules": ["flyswatting"] },
+									{ "count": 1, "modules": ["HitmanModule"] },
+									{ "count": 1, "modules": ["leds"] },
+									{ "count": 1, "modules": ["mirror"] },
+									{ "count": 1, "modules": ["RedHerring"] },
+									{ "count": 1, "modules": ["squeeze"] },
+									{ "count": 1, "modules": ["warningSigns"] },
+									{ "count": 1, "modules": ["Words"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14621 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["base1"] },
+									{ "count": 1, "modules": ["candyLand"] },
+									{ "count": 1, "modules": ["cursorMazeModule"] },
+									{ "count": 1, "modules": ["GrayButtonModule"] },
+									{ "count": 1, "modules": ["invisymbol"] },
+									{ "count": 1, "modules": ["letterMath"] },
+									{ "count": 1, "modules": ["myMom"] },
+									{ "count": 1, "modules": ["PurchasingProperties"] },
+									{ "count": 1, "modules": ["shogiIdentification"] },
+									{ "count": 1, "modules": ["ShutTheBox"] },
+									{ "count": 1, "modules": ["UNO"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14622 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["4buttons"] },
+									{ "count": 1, "modules": ["bafflingBox"] },
+									{ "count": 1, "modules": ["factoryCode"] },
+									{ "count": 1, "modules": ["factoryCubes"] },
+									{ "count": 1, "modules": ["marcoPolo"] },
+									{ "count": 1, "modules": ["NeutralButtonModule"] },
+									{ "count": 1, "modules": ["NotColoredSquaresModule"] },
+									{ "count": 1, "modules": ["notes"] },
+									{ "count": 1, "modules": ["signLanguage"] },
+									{ "count": 1, "modules": ["GSSurroundingButtons"] },
+									{ "count": 1, "modules": ["USACycle"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14623 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["double_on"] },
+									{ "count": 1, "modules": ["keyedButtons"] },
+									{ "count": 1, "modules": ["logicPlumbing"] },
+									{ "count": 1, "modules": ["MatchingSigns"] },
+									{ "count": 1, "modules": ["mini"] },
+									{ "count": 1, "modules": ["NiftyNumber"] },
+									{ "count": 1, "modules": ["oneitemOneMeal"] },
+									{ "count": 1, "modules": ["parity"] },
+									{ "count": 1, "modules": ["PigfairCipher"] },
+									{ "count": 1, "modules": ["RDKeypad"] },
+									{ "count": 1, "modules": ["Wordle"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14624 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["Fillominordle"] },
+									{ "count": 1, "modules": ["FittingInModule"] },
+									{ "count": 1, "modules": ["theGreenWireModule"] },
+									{ "count": 1, "modules": ["midCircle"] },
+									{ "count": 1, "modules": ["Patterns"] },
+									{ "count": 1, "modules": ["ReadingBetweentheLines"] },
+									{ "count": 1, "modules": ["saulGoodmanButton"] },
+									{ "count": 1, "modules": ["scrutinySquares"] },
+									{ "count": 1, "modules": ["technicalButtons"] },
+									{ "count": 1, "modules": ["translatedKeypadModule"] },
+									{ "count": 1, "modules": ["WanderModule"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14625 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["alphabetButtons"] },
+									{ "count": 1, "modules": ["ChesswordModule"] },
+									{ "count": 1, "modules": ["epicShapes"] },
+									{ "count": 1, "modules": ["FindTheInvisibleCowModule"] },
+									{ "count": 1, "modules": ["funnyNumber"] },
+									{ "count": 1, "modules": ["genMaze"] },
+									{ "count": 1, "modules": ["mercury"] },
+									{ "count": 1, "modules": ["Quadrants"] },
+									{ "count": 1, "modules": ["Rambopo"] },
+									{ "count": 1, "modules": ["schulteTable"] },
+									{ "count": 1, "modules": ["yoshiEgg"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14626 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["activities"] },
+									{ "count": 1, "modules": ["baseOn"] },
+									{ "count": 1, "modules": ["blindfoldedRubiksClockModule"] },
+									{ "count": 1, "modules": ["fourOperands"] },
+									{ "count": 1, "modules": ["GTACheats"] },
+									{ "count": 1, "modules": ["memoryWires"] },
+									{ "count": 1, "modules": ["compMorse"] },
+									{ "count": 1, "modules": ["RecursivePassword"] },
+									{ "count": 1, "modules": ["shapesAndColors"] },
+									{ "count": 1, "modules": ["subway"] },
+									{ "count": 1, "modules": ["turingMachine"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14627 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["colorPong"] },
+									{ "count": 1, "modules": ["CruelSimpleton"] },
+									{ "count": 1, "modules": ["GSDialTrial"] },
+									{ "count": 1, "modules": ["FollowMe"] },
+									{ "count": 1, "modules": ["gameboyCart"] },
+									{ "count": 1, "modules": ["MulticoloredDigits"] },
+									{ "count": 1, "modules": ["GL_nokiaModule"] },
+									{ "count": 1, "modules": ["periodicWordsRB"] },
+									{ "count": 1, "modules": ["PolybiusSquare"] },
+									{ "count": 1, "modules": ["quantumPasswords"] },
+									{ "count": 1, "modules": ["wasdModule"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14628 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["GSTwentyFour"] },
+									{ "count": 1, "modules": ["bigBikeRepair"] },
+									{ "count": 1, "modules": ["grandPiano"] },
+									{ "count": 1, "modules": ["jobApplication"] },
+									{ "count": 1, "modules": ["LengthyLockdown"] },
+									{ "count": 1, "modules": ["mazeSwap"] },
+									{ "count": 1, "modules": ["numbrix"] },
+									{ "count": 1, "modules": ["PointGrid"] },
+									{ "count": 1, "modules": ["rasterPrime"] },
+									{ "count": 1, "modules": ["Sporglers"] },
+									{ "count": 1, "modules": ["zoomModule"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14629 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["CrazyMazeModule"] },
+									{ "count": 1, "modules": ["diamonds"] },
+									{ "count": 1, "modules": ["GSFourElements"] },
+									{ "count": 1, "modules": ["HaikuModule"] },
+									{ "count": 1, "modules": ["NavigationDeterminationModule"] },
+									{ "count": 1, "modules": ["patternWires"] },
+									{ "count": 1, "modules": ["simultaneousSimons"] },
+									{ "count": 1, "modules": ["soilClassification"] },
+									{ "count": 1, "modules": ["swish"] },
+									{ "count": 1, "modules": ["TechnicalKeypad"] },
+									{ "count": 1, "modules": ["XORShiftModule"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14630 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["cityPlanning"] },
+									{ "count": 1, "modules": ["clappingMusic"] },
+									{ "count": 1, "modules": ["encoloryption"] },
+									{ "count": 1, "modules": ["keypass"] },
+									{ "count": 1, "modules": ["nim"] },
+									{ "count": 1, "modules": ["GSNumberCruncher"] },
+									{ "count": 1, "modules": ["QModule"] },
+									{ "count": 1, "modules": ["settingCharges"] },
+									{ "count": 1, "modules": ["soda"] },
+									{ "count": 1, "modules": ["SubtractionModule"] },
+									{ "count": 1, "modules": ["GSWinningLine"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14631 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["binarySquares"] },
+									{ "count": 1, "modules": ["ducks"] },
+									{ "count": 1, "modules": ["karnaugh"] },
+									{ "count": 1, "modules": ["labyrinthMadness"] },
+									{ "count": 1, "modules": ["metalmaths"] },
+									{ "count": 1, "modules": ["MultiverseHotline"] },
+									{ "count": 1, "modules": ["GSNormalProbability"] },
+									{ "count": 1, "modules": ["hexaterminals"] },
+									{ "count": 1, "modules": ["snatchersMap"] },
+									{ "count": 1, "modules": ["supermarketScramble"] },
+									{ "count": 1, "modules": ["theTissueBox"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14632 }
+						},
+						{
+							"data": {
+								"time": 1200,
+								"pools": [
+									{ "count": 1, "modules": ["alcoholicRampageModule"] },
+									{ "count": 1, "modules": ["ballDial"] },
+									{ "count": 1, "modules": ["BaseConversion"] },
+									{ "count": 1, "modules": ["breakers"] },
+									{ "count": 1, "modules": ["curlyWires"] },
+									{ "count": 1, "modules": ["theLight"] },
+									{ "count": 1, "modules": ["LogicCircuits"] },
+									{ "count": 1, "modules": ["lyingButtons"] },
+									{ "count": 1, "modules": ["scattershot"] },
+									{ "count": 1, "modules": ["someButtons"] },
+									{ "count": 1, "modules": ["triskaideka"] }
+								],
+								"modules": 11,
+								"strikes": 5,
+								"widgets": 5
+							},
+							"where": { "id": 14633 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 794,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10699",
+			"name": "Module Marathon",
+			"action": "update",
+			"timestamp": "2024-10-26T10:27:02.635Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=5963207f0a5e3595a32411300006ce52beb958da" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=e60d8f5050feba1ce9dbd79b4ce110f22c0c8d59" }
+		},
+		{
+			"id": 795,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60630",
+			"name": "Undefined 47||Framzo, nameless",
+			"action": "update",
+			"timestamp": "2024-10-26T12:57:30.122Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 796,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60631",
+			"name": "Eldoraigne||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-10-26T12:58:40.139Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 797,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60632",
+			"name": "Doringkloof||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-10-26T12:59:23.445Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 798,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60633",
+			"name": "Fnuuy||Sierra, AzaFTW",
+			"action": "update",
+			"timestamp": "2024-10-26T12:59:59.682Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 799,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60634",
+			"name": "FMN Hell 3||BladePL",
+			"action": "update",
+			"timestamp": "2024-10-26T13:00:35.645Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 800,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60635",
+			"name": "Undefined 47||nameless, Framzo",
+			"action": "update",
+			"timestamp": "2024-10-26T13:02:03.010Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 801,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59173",
+			"name": "Asmir's 47||denial140",
+			"action": "update",
+			"timestamp": "2024-10-26T13:02:24.119Z",
+			"before": {
+				"time": 2355.27,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=89c487237a7736b41b6dc4156c90d2edfb72488b;bomb=8W3ED6"
+				]
+			},
+			"after": {
+				"time": 2467.68,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=b7704df7c28185cef06d93369b27166e515ae698;bomb=UA5TN1",
+					"https://youtu.be/CrrkPce37dI"
+				]
+			}
+		},
+		{
+			"id": 802,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60636",
+			"name": "Asmir's 47||denial140",
+			"action": "delete",
+			"timestamp": "2024-10-26T13:02:27.659Z",
+			"before": {
+				"id": 60636,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 2467.68,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=b7704df7c28185cef06d93369b27166e515ae698;bomb=UA5TN1",
+					"https://youtu.be/CrrkPce37dI"
+				],
+				"verified": false,
+				"dateAdded": "2024-10-24T08:10:04.195Z",
+				"missionId": 9629,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 803,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60637",
+			"name": "Doringkloof||c12, Termet",
+			"action": "update",
+			"timestamp": "2024-10-26T13:03:52.320Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 804,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60638",
+			"name": "Olievenhoutbosch||AzaFTW, Termet",
+			"action": "update",
+			"timestamp": "2024-10-26T13:04:23.460Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 805,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60640",
+			"name": "Try Not To Forget||Benjamin, Bianca, Burniel",
+			"action": "update",
+			"timestamp": "2024-10-26T13:04:31.702Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 806,
+			"userId": "594991798045114389",
+			"model": "MissionPack",
+			"recordId": "615",
+			"name": "The MIBsion Pack",
+			"action": "create",
+			"timestamp": "2024-10-26T17:26:35.509Z"
+		},
+		{
+			"id": 807,
+			"userId": "104464697775882240",
+			"model": "Completion",
+			"recordId": "60646",
+			"name": "Seifar Toy Company Reservation||Framzo, nameless",
+			"action": "create",
+			"timestamp": "2024-10-26T20:26:44.298Z"
+		},
+		{
+			"id": 808,
+			"userId": "261983800429510658",
+			"model": "Completion",
+			"recordId": "60647",
+			"name": "Seifar Toy Company Reservation||nameless, Framzo",
+			"action": "create",
+			"timestamp": "2024-10-26T20:43:20.442Z"
+		},
+		{
+			"id": 809,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60648",
+			"name": "QN!: FCDT||denial140",
+			"action": "create",
+			"timestamp": "2024-10-27T06:37:25.764Z"
+		},
+		{
+			"id": 810,
+			"userId": "486602438103531520",
+			"model": "MissionPack",
+			"recordId": "615",
+			"name": "The MIBsion Pack",
+			"action": "update",
+			"timestamp": "2024-10-27T09:59:42.632Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 811,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60641",
+			"name": "17 Again||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-10-27T10:00:30.263Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 812,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60642",
+			"name": "Oompa Loompa Boon Poppycock||Termet",
+			"action": "update",
+			"timestamp": "2024-10-27T10:01:00.841Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 813,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60649",
+			"name": "QN!: FCDT||Kugel",
+			"action": "create",
+			"timestamp": "2024-10-27T10:03:10.382Z"
+		},
+		{
+			"id": 814,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59496",
+			"name": "Boss Module Endurance||denial140",
+			"action": "update",
+			"timestamp": "2024-10-27T10:03:46.793Z",
+			"before": {
+				"time": 11151.18,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=8565460a4df85194266a88131cb871df28383986;bomb=ZI3WK3"
+				]
+			},
+			"after": {
+				"time": 11796.54,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=fb7129ec972a66a41cd22fe3427d7c240c2f0620;bomb=V53BX6"
+				]
+			}
+		},
+		{
+			"id": 815,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60643",
+			"name": "Boss Module Endurance||denial140",
+			"action": "delete",
+			"timestamp": "2024-10-27T10:03:46.804Z",
+			"before": {
+				"id": 60643,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 11796.54,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=fb7129ec972a66a41cd22fe3427d7c240c2f0620;bomb=V53BX6"
+				],
+				"verified": false,
+				"dateAdded": "2024-10-25T22:41:31.371Z",
+				"missionId": 9887,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 816,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60644",
+			"name": "Divorce Papers: A Bored Ape Odyssey||Sierra",
+			"action": "update",
+			"timestamp": "2024-10-27T10:04:16.971Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 817,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60645",
+			"name": "Centurion||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-10-27T10:05:10.664Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 818,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60646",
+			"name": "Seifar Toy Company Reservation||Framzo, nameless",
+			"action": "update",
+			"timestamp": "2024-10-27T10:05:51.264Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 819,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60647",
+			"name": "Seifar Toy Company Reservation||nameless, Framzo",
+			"action": "update",
+			"timestamp": "2024-10-27T10:06:17.304Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 820,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60648",
+			"name": "QN!: FCDT||denial140",
+			"action": "update",
+			"timestamp": "2024-10-27T10:08:33.894Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 821,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60649",
+			"name": "QN!: FCDT||Kugel",
+			"action": "update",
+			"timestamp": "2024-10-27T10:08:48.927Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 822,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60650",
+			"name": "17 Again||Termet, c12, Dani was here",
+			"action": "create",
+			"timestamp": "2024-10-27T10:46:05.383Z"
+		},
+		{
+			"id": 823,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60651",
+			"name": "NoT!: Niigo||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-27T17:35:11.816Z"
+		},
+		{
+			"id": 824,
+			"userId": "483182665776889856",
+			"model": "Completion",
+			"recordId": "60652",
+			"name": "In2sity||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-10-27T19:30:00.355Z"
+		},
+		{
+			"id": 825,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60653",
+			"name": "Possibly Impossible||BladePL",
+			"action": "create",
+			"timestamp": "2024-10-27T21:07:01.922Z"
+		},
+		{
+			"id": 826,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60654",
+			"name": "Frontier Alpha||denial140",
+			"action": "create",
+			"timestamp": "2024-10-28T07:38:40.876Z"
+		},
+		{
+			"id": 827,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60655",
+			"name": "Dove||Termet, c12",
+			"action": "create",
+			"timestamp": "2024-10-28T12:48:35.134Z"
+		},
+		{
+			"id": 828,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60656",
+			"name": "Nothing To Spare: Pressured To Fail||Faith",
+			"action": "create",
+			"timestamp": "2024-10-28T14:41:10.450Z"
+		},
+		{
+			"id": 829,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60657",
+			"name": "Great Berate Practice||Sierra, Termet, Faith",
+			"action": "create",
+			"timestamp": "2024-10-28T16:34:32.680Z"
+		},
+		{
+			"id": 830,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60650",
+			"name": "17 Again||Termet, c12, Dani was here",
+			"action": "update",
+			"timestamp": "2024-10-28T19:42:28.605Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 831,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10763",
+			"name": "NoT!: Niigo",
+			"action": "update",
+			"timestamp": "2024-10-28T19:42:45.712Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 832,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60651",
+			"name": "NoT!: Niigo||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-28T19:42:45.722Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 833,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10675",
+			"name": "In2sity",
+			"action": "update",
+			"timestamp": "2024-10-28T19:43:19.179Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 834,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60652",
+			"name": "In2sity||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-10-28T19:43:19.192Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 835,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60653",
+			"name": "Possibly Impossible||BladePL",
+			"action": "update",
+			"timestamp": "2024-10-28T19:43:38.323Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 836,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10786",
+			"name": "[[UPDATE]] Crazyturion 2",
+			"action": "create",
+			"timestamp": "2024-10-29T01:31:03.025Z"
+		},
+		{
+			"id": 837,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10786",
+			"name": "[[UPDATE]] Crazyturion 2",
+			"action": "delete",
+			"timestamp": "2024-10-29T01:31:14.687Z",
+			"before": {
+				"id": 10786,
+				"name": "[[UPDATE]] Crazyturion 2",
+				"notes": null,
+				"authors": [],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=8dd5a8eb8815681cd6d43ae1dfb3f90e0c159d2c",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_Crazyturion_CrazyturionV2",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-10-29T01:30:55.243Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "213189526837919745",
+				"designedForTP": false,
+				"missionPackId": 475
+			}
+		},
+		{
+			"id": 838,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10787",
+			"name": "[[UPDATE]] Crazyturion 2",
+			"action": "create",
+			"timestamp": "2024-10-29T01:31:43.286Z"
+		},
+		{
+			"id": 839,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10056",
+			"name": "Crazyturion 2",
+			"action": "update",
+			"timestamp": "2024-10-29T01:32:53.901Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=953f78d15896c88007f47995a1d56d65f41f8f89" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 10800,
+							"pools": [
+								{ "count": 1, "modules": ["3dTunnels"] },
+								{ "count": 1, "modules": ["addNauseam"] },
+								{ "count": 1, "modules": ["alphabet"] },
+								{ "count": 1, "modules": ["BartendingModule"] },
+								{ "count": 1, "modules": ["bridges"] },
+								{ "count": 1, "modules": ["characterShift"] },
+								{ "count": 1, "modules": ["ChickenNuggets"] },
+								{ "count": 1, "modules": ["KritBlackjack"] },
+								{ "count": 1, "modules": ["ColoredSwitchesModule"] },
+								{ "count": 1, "modules": ["Venn"] },
+								{ "count": 1, "modules": ["CornersModule"] },
+								{ "count": 1, "modules": ["curriculum"] },
+								{ "count": 1, "modules": ["decimation"] },
+								{ "count": 1, "modules": ["doofenshmirtzEvilIncModule"] },
+								{ "count": 1, "modules": ["settingCharges"] },
+								{ "count": 1, "modules": ["YahtzeeModule"] },
+								{ "count": 1, "modules": ["encryptedMaze"] },
+								{ "count": 1, "modules": ["KritMicroModules"] },
+								{ "count": 1, "modules": ["faultyrgbMaze"] },
+								{ "count": 1, "modules": ["flowerPatch"] },
+								{ "count": 1, "modules": ["forgetThis"] },
+								{ "count": 1, "modules": ["GameOfLifeSimple"] },
+								{ "count": 1, "modules": ["gettinFunkyModule"] },
+								{ "count": 1, "modules": ["partialDerivatives"] },
+								{ "count": 1, "modules": ["SettingSail"] },
+								{ "count": 1, "modules": ["hexOrbits"] },
+								{ "count": 1, "modules": ["hieroglyphics"] },
+								{ "count": 1, "modules": ["HitmanModule"] },
+								{ "count": 1, "modules": ["impostor"] },
+								{ "count": 1, "modules": ["TheKanyeEncounter"] },
+								{ "count": 1, "modules": ["klaxon"] },
+								{ "count": 1, "modules": ["lasers"] },
+								{ "count": 1, "modules": ["maskedMorse"] },
+								{ "count": 1, "modules": ["maze3"] },
+								{ "count": 1, "modules": ["metamem"] },
+								{ "count": 1, "modules": ["mortalKombat"] },
+								{ "count": 1, "modules": ["nameCodes"] },
+								{ "count": 1, "modules": ["newline"] },
+								{ "count": 1, "modules": ["matchematics"] },
+								{ "count": 1, "modules": ["anomia"] },
+								{ "count": 1, "modules": ["notWordSearch"] },
+								{ "count": 1, "modules": ["notX01"] },
+								{ "count": 1, "modules": ["oldFogey"] },
+								{ "count": 1, "modules": ["palindromes"] },
+								{ "count": 1, "modules": ["spwizPerspectivePegs"] },
+								{ "count": 1, "modules": ["pixelcipher"] },
+								{ "count": 1, "modules": ["AquariumModule"] },
+								{ "count": 1, "modules": ["rgbCombination"] },
+								{ "count": 1, "modules": ["theRule"] },
+								{ "count": 1, "modules": ["scavengerHunt"] },
+								{ "count": 1, "modules": ["KritScripts"] },
+								{ "count": 1, "modules": ["wastemanagement"] },
+								{ "count": 1, "modules": ["sevenDeadlySins"] },
+								{ "count": 1, "modules": ["Signals"] },
+								{ "count": 1, "modules": ["FollowingOrders"] },
+								{ "count": 1, "modules": ["SimonShoutsModule"] },
+								{ "count": 1, "modules": ["SimonShrieksModule"] },
+								{ "count": 1, "modules": ["SimonSpinsModule"] },
+								{ "count": 1, "modules": ["simonSupports"] },
+								{ "count": 1, "modules": ["PolybiusSquare"] },
+								{ "count": 1, "modules": ["Tangrams"] },
+								{ "count": 1, "modules": ["Telepathy"] },
+								{ "count": 1, "modules": ["theTriangleButton"] },
+								{ "count": 1, "modules": ["UncoloredSquaresModule"] },
+								{ "count": 1, "modules": ["TripleTraversalModule"] },
+								{ "count": 1, "modules": ["UNO"] },
+								{ "count": 1, "modules": ["USACycle"] },
+								{ "count": 1, "modules": ["RailwayCargoLoading"] },
+								{ "count": 1, "modules": ["VaricoloredSquaresModule"] },
+								{ "count": 1, "modules": ["VoltorbFlip"] },
+								{ "count": 1, "modules": ["disorderedKeys"] },
+								{ "count": 1, "modules": ["wire"] },
+								{ "count": 1, "modules": ["X01"] },
+								{ "count": 1, "modules": ["XRayModule"] },
+								{ "count": 1, "modules": ["offKeys"] },
+								{ "count": 1, "modules": ["multitracking"] },
+								{ "count": 1, "modules": ["hexNull"] },
+								{ "count": 1, "modules": ["starstruck"] },
+								{ "count": 1, "modules": ["gemDivision"] },
+								{ "count": 1, "modules": ["ChesswordModule"] },
+								{ "count": 1, "modules": ["zeroZero"] },
+								{ "count": 1, "modules": ["quilting"] },
+								{ "count": 1, "modules": ["subblyJubbly"] },
+								{ "count": 1, "modules": ["illMorse"] },
+								{ "count": 1, "modules": ["logicPlumbing"] },
+								{ "count": 1, "modules": ["answerSmashModule"] },
+								{ "count": 1, "modules": ["DecolourFlashModule"] },
+								{ "count": 1, "modules": ["ForgetsUltimateShowdownModule"] },
+								{ "count": 1, "modules": ["compMorse"] },
+								{ "count": 1, "modules": ["flyswatting"] },
+								{ "count": 1, "modules": ["BombItModule"] },
+								{ "count": 1, "modules": ["FittingInModule"] },
+								{ "count": 1, "modules": ["wordCount"] },
+								{ "count": 1, "modules": ["mercury"] },
+								{ "count": 1, "modules": ["videoPoker"] },
+								{ "count": 1, "modules": ["shapesAndColors"] },
+								{ "count": 1, "modules": ["RubiksSlideModule"] },
+								{ "count": 1, "modules": ["malfunctions"] },
+								{ "count": 1, "modules": ["xelQuickTimeEvents"] },
+								{ "count": 1, "modules": ["keypadSeq"] },
+								{ "count": 1, "modules": ["EvilWordSearchModule"] }
+							],
+							"modules": 101,
+							"strikes": 10,
+							"widgets": 5
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=8dd5a8eb8815681cd6d43ae1dfb3f90e0c159d2c"
+			}
+		},
+		{
+			"id": 840,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10787",
+			"name": "[[UPDATE]] Crazyturion 2",
+			"action": "delete",
+			"timestamp": "2024-10-29T01:32:53.921Z",
+			"before": {
+				"id": 10787,
+				"name": "[[UPDATE]] Crazyturion 2",
+				"notes": null,
+				"authors": ["Crazycaleb"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=8dd5a8eb8815681cd6d43ae1dfb3f90e0c159d2c",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_Crazyturion_CrazyturionV2",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-10-29T01:31:20.403Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "213189526837919745",
+				"designedForTP": false,
+				"missionPackId": 475
+			}
+		},
+		{
+			"id": 841,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60658",
+			"name": "By Popular Demand||denial140",
+			"action": "create",
+			"timestamp": "2024-10-29T06:14:37.631Z"
+		},
+		{
+			"id": 842,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60659",
+			"name": "Wire Madness||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-10-29T07:10:59.994Z"
+		},
+		{
+			"id": 843,
+			"userId": "208633883544125440",
+			"model": "Mission",
+			"recordId": "10788",
+			"name": "Baking Soda",
+			"action": "create",
+			"timestamp": "2024-10-29T16:18:16.446Z"
+		},
+		{
+			"id": 844,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60660",
+			"name": "Soloist||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-10-30T07:29:29.873Z"
+		},
+		{
+			"id": 845,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60661",
+			"name": "Great Berate Practice||denial140",
+			"action": "create",
+			"timestamp": "2024-10-30T08:05:54.798Z"
+		},
+		{
+			"id": 846,
+			"userId": "370356150350249984",
+			"model": "Completion",
+			"recordId": "60662",
+			"name": "Sky's the Minimum||Aaron Kitty Boiii",
+			"action": "create",
+			"timestamp": "2024-10-30T08:47:45.275Z"
+		},
+		{
+			"id": 847,
+			"userId": "566568608755613731",
+			"model": "Completion",
+			"recordId": "60663",
+			"name": "Olievenhoutbosch||Coolpapabell, Dani was here, FourAndAHalf",
+			"action": "create",
+			"timestamp": "2024-10-30T17:42:16.259Z"
+		},
+		{
+			"id": 848,
+			"userId": "482616311822680086",
+			"model": "Completion",
+			"recordId": "60664",
+			"name": "Easy Challenge||Speeri",
+			"action": "create",
+			"timestamp": "2024-10-30T18:31:21.092Z"
+		},
+		{
+			"id": 849,
+			"userId": "370356150350249984",
+			"model": "Completion",
+			"recordId": "60665",
+			"name": "Professional EFM||Aaron Kitty Boiii",
+			"action": "create",
+			"timestamp": "2024-10-31T02:03:18.915Z"
+		},
+		{
+			"id": 850,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60654",
+			"name": "Frontier Alpha||denial140",
+			"action": "update",
+			"timestamp": "2024-10-31T07:38:03.744Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 851,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60655",
+			"name": "Dove||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-10-31T07:38:47.041Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 852,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60656",
+			"name": "Nothing To Spare: Pressured To Fail||Faith",
+			"action": "update",
+			"timestamp": "2024-10-31T07:39:31.241Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 853,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60657",
+			"name": "Great Berate Practice||Sierra, Termet, Faith",
+			"action": "update",
+			"timestamp": "2024-10-31T07:41:19.126Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 854,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60657",
+			"name": "Great Berate Practice||Sierra, Termet, Faith",
+			"action": "update",
+			"timestamp": "2024-10-31T07:41:33.127Z",
+			"before": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=b66007e07813e862f66ed292d70738339c4cd748;bomb=TB9EE7",
+					"https://youtu.be/iS5LtdJ5S-I",
+					"https://youtu.be/bAjQlXBXymY"
+				]
+			},
+			"after": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=b66007e07813e862f66ed292d70738339c4cd748;bomb=TB9EE7",
+					"https://youtu.be/iS5LtdJ5S-I",
+					"https://www.youtube.com/watch?v=u2OGiCpaX7I"
+				]
+			}
+		},
+		{
+			"id": 855,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59167",
+			"name": "By Popular Demand||denial140",
+			"action": "update",
+			"timestamp": "2024-10-31T07:42:57.027Z",
+			"before": {
+				"time": 1157.49,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=b09855754ee5920b789e4fc43d09d13028371783;bomb=T79QL7"
+				]
+			},
+			"after": {
+				"time": 1598.06,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=c9a1ad5808bc746ef9025aaf01c3bec3517185cd;bomb=HZ9JK3",
+					"https://youtu.be/Cmj_hVeVKtY"
+				]
+			}
+		},
+		{
+			"id": 856,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60658",
+			"name": "By Popular Demand||denial140",
+			"action": "delete",
+			"timestamp": "2024-10-31T07:42:57.037Z",
+			"before": {
+				"id": 60658,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 1598.06,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=c9a1ad5808bc746ef9025aaf01c3bec3517185cd;bomb=HZ9JK3",
+					"https://youtu.be/Cmj_hVeVKtY"
+				],
+				"verified": false,
+				"dateAdded": "2024-10-29T06:14:06.704Z",
+				"missionId": 9621,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 857,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60666",
+			"name": "Organisation Rush||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-10-31T08:14:50.052Z"
+		},
+		{
+			"id": 858,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60667",
+			"name": "Easy Challenge||Termet, c12",
+			"action": "create",
+			"timestamp": "2024-10-31T14:06:01.095Z"
+		},
+		{
+			"id": 859,
+			"userId": "649278621550116864",
+			"model": "Completion",
+			"recordId": "60668",
+			"name": "Organisation Rush||Lily",
+			"action": "create",
+			"timestamp": "2024-10-31T16:36:51.417Z"
+		},
+		{
+			"id": 860,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60669",
+			"name": "Centurion||Termet",
+			"action": "create",
+			"timestamp": "2024-10-31T17:10:33.466Z"
+		},
+		{
+			"id": 861,
+			"userId": "705507300634263653",
+			"model": "Completion",
+			"recordId": "60670",
+			"name": "SuperSOLOable||Possessed",
+			"action": "create",
+			"timestamp": "2024-10-31T21:56:33.421Z"
+		},
+		{
+			"id": 862,
+			"userId": "1257537901265162271",
+			"model": "Completion",
+			"recordId": "60671",
+			"name": "Praetorian New Ones||c12",
+			"action": "create",
+			"timestamp": "2024-11-02T08:19:21.331Z"
+		},
+		{
+			"id": 863,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60672",
+			"name": "Irene||denial140",
+			"action": "create",
+			"timestamp": "2024-11-02T12:58:45.507Z"
+		},
+		{
+			"id": 864,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60673",
+			"name": "Asmir's 47||Termet",
+			"action": "create",
+			"timestamp": "2024-11-02T17:53:17.648Z"
+		},
+		{
+			"id": 865,
+			"userId": "257492059101855745",
+			"model": "Completion",
+			"recordId": "60674",
+			"name": "Easy Challenge||Zappyjro",
+			"action": "create",
+			"timestamp": "2024-11-02T20:55:04.803Z"
+		},
+		{
+			"id": 866,
+			"userId": "294221057311899649",
+			"model": "Completion",
+			"recordId": "60675",
+			"name": "Olievenhoutbosch||GreenPower, Lucco, Guck, LeJusDOrange",
+			"action": "create",
+			"timestamp": "2024-11-02T23:41:55.594Z"
+		},
+		{
+			"id": 867,
+			"userId": "488806494872272898",
+			"model": "Completion",
+			"recordId": "60676",
+			"name": "'Not' Centurion||Men in Black",
+			"action": "create",
+			"timestamp": "2024-11-03T03:30:58.045Z"
+		},
+		{
+			"id": 868,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60677",
+			"name": "An Idol||Sierra",
+			"action": "create",
+			"timestamp": "2024-11-03T23:53:58.329Z"
+		},
+		{
+			"id": 869,
+			"userId": "370356150350249984",
+			"model": "Completion",
+			"recordId": "60678",
+			"name": "Professional Group||Aaron Kitty Boiii",
+			"action": "create",
+			"timestamp": "2024-11-04T04:08:05.004Z"
+		},
+		{
+			"id": 870,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60679",
+			"name": "Praetorian New Ones||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-11-04T06:54:00.961Z"
+		},
+		{
+			"id": 871,
+			"userId": "370356150350249984",
+			"model": "Completion",
+			"recordId": "60680",
+			"name": "Color Square Madness||Aaron Kitty Boiii",
+			"action": "create",
+			"timestamp": "2024-11-04T08:03:21.410Z"
+		},
+		{
+			"id": 872,
+			"userId": "244616599443603456",
+			"model": "Completion",
+			"recordId": "60681",
+			"name": "Core's Entrance||Awesome7285, weird, Sierra",
+			"action": "create",
+			"timestamp": "2024-11-04T14:05:52.203Z"
+		},
+		{
+			"id": 873,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60682",
+			"name": "Simplifier||Termet",
+			"action": "create",
+			"timestamp": "2024-11-04T20:17:29.199Z"
+		},
+		{
+			"id": 874,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60683",
+			"name": "One Iconic Army||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-11-05T02:20:51.289Z"
+		},
+		{
+			"id": 875,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60684",
+			"name": "Solo Madness||tactualdwarf519",
+			"action": "create",
+			"timestamp": "2024-11-05T05:32:03.982Z"
+		},
+		{
+			"id": 876,
+			"userId": "488806494872272898",
+			"model": "Completion",
+			"recordId": "60685",
+			"name": "Doringkloof||Men in Black",
+			"action": "create",
+			"timestamp": "2024-11-05T05:47:29.124Z"
+		},
+		{
+			"id": 877,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60686",
+			"name": "A Koopa's Favorite Modules||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-11-05T07:23:41.508Z"
+		},
+		{
+			"id": 878,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60687",
+			"name": "CentuRYAN||denial140",
+			"action": "create",
+			"timestamp": "2024-11-05T15:48:57.886Z"
+		},
+		{
+			"id": 879,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60688",
+			"name": "Just Vibin'||denial140",
+			"action": "create",
+			"timestamp": "2024-11-06T02:38:35.506Z"
+		},
+		{
+			"id": 880,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60689",
+			"name": "Verbal Madness||Crazycaleb",
+			"action": "create",
+			"timestamp": "2024-11-06T04:17:17.455Z"
+		},
+		{
+			"id": 881,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60690",
+			"name": "BlvdBroken's Bomb of Bangers (Climb)||Kugel, Termet, AzaFTW",
+			"action": "create",
+			"timestamp": "2024-11-06T05:45:55.046Z"
+		},
+		{
+			"id": 882,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60691",
+			"name": "Gotta Be Fast||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-11-06T06:21:32.625Z"
+		},
+		{
+			"id": 883,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60659",
+			"name": "Wire Madness||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-06T07:48:59.041Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 884,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60660",
+			"name": "Soloist||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-06T07:49:22.270Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 885,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60661",
+			"name": "Great Berate Practice||denial140",
+			"action": "update",
+			"timestamp": "2024-11-06T07:50:17.656Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 886,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60662",
+			"name": "Sky's the Minimum||Aaron Kitty Boiii",
+			"action": "update",
+			"timestamp": "2024-11-06T07:50:56.721Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 887,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60663",
+			"name": "Olievenhoutbosch||Coolpapabell, Dani was here, FourAndAHalf",
+			"action": "update",
+			"timestamp": "2024-11-06T07:52:24.173Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 888,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60664",
+			"name": "Easy Challenge||Speeri",
+			"action": "update",
+			"timestamp": "2024-11-06T07:53:27.213Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 889,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60665",
+			"name": "Professional EFM||Aaron Kitty Boiii",
+			"action": "update",
+			"timestamp": "2024-11-06T07:54:43.022Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 890,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60666",
+			"name": "Organisation Rush||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-06T07:55:32.605Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 891,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60667",
+			"name": "Easy Challenge||Termet, c12",
+			"action": "update",
+			"timestamp": "2024-11-06T07:56:46.344Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 892,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60668",
+			"name": "Organisation Rush||Lily",
+			"action": "update",
+			"timestamp": "2024-11-06T07:57:18.752Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 893,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60669",
+			"name": "Centurion||Termet",
+			"action": "update",
+			"timestamp": "2024-11-06T07:57:41.868Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 894,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60671",
+			"name": "Praetorian New Ones||c12",
+			"action": "update",
+			"timestamp": "2024-11-06T07:58:28.782Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 895,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59808",
+			"name": "Irene||denial140",
+			"action": "update",
+			"timestamp": "2024-11-06T07:59:22.151Z",
+			"before": {
+				"time": 467,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=b53b1000acd10bba07efc562cd6e6488cf8e7a2f;bomb=XW6QZ3"
+				]
+			},
+			"after": {
+				"time": 1400.72,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=00f6f3c5a91e163d21cdab5cfc94154fff34a0de;bomb=VI7WU3",
+					"https://youtu.be/Vc1JePsjSjI"
+				]
+			}
+		},
+		{
+			"id": 896,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60672",
+			"name": "Irene||denial140",
+			"action": "delete",
+			"timestamp": "2024-11-06T07:59:22.160Z",
+			"before": {
+				"id": 60672,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 1400.72,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=00f6f3c5a91e163d21cdab5cfc94154fff34a0de;bomb=VI7WU3",
+					"https://youtu.be/Vc1JePsjSjI"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-02T12:32:42.998Z",
+				"missionId": 9880,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 897,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60692",
+			"name": "A Sensible Challenge||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-11-06T08:12:51.703Z"
+		},
+		{
+			"id": 898,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10789",
+			"name": "Vocal Catastrophe",
+			"action": "create",
+			"timestamp": "2024-11-06T13:35:02.048Z"
+		},
+		{
+			"id": 899,
+			"userId": "257492059101855745",
+			"model": "Completion",
+			"recordId": "60693",
+			"name": "Just Vibin'||Zappyjro",
+			"action": "create",
+			"timestamp": "2024-11-06T20:14:39.346Z"
+		},
+		{
+			"id": 900,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60694",
+			"name": "A Sensible Challenge||tactualdwarf519",
+			"action": "create",
+			"timestamp": "2024-11-06T22:43:01.764Z"
+		},
+		{
+			"id": 901,
+			"userId": "104464697775882240",
+			"model": "Completion",
+			"recordId": "60695",
+			"name": "Just Vibin'||Framzo, nameless",
+			"action": "create",
+			"timestamp": "2024-11-06T22:50:06.237Z"
+		},
+		{
+			"id": 902,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60696",
+			"name": "Thank Goodness You're Here!||AzaFTW, Burniel, Danielstigman",
+			"action": "create",
+			"timestamp": "2024-11-07T03:08:31.093Z"
+		},
+		{
+			"id": 903,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10790",
+			"name": "Every Copy of KTaNE Is Personalised",
+			"action": "create",
+			"timestamp": "2024-11-07T09:24:36.095Z"
+		},
+		{
+			"id": 904,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60673",
+			"name": "Asmir's 47||Termet",
+			"action": "update",
+			"timestamp": "2024-11-07T09:31:26.223Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 905,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60674",
+			"name": "Easy Challenge||Zappyjro",
+			"action": "update",
+			"timestamp": "2024-11-07T09:31:44.016Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 906,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60697",
+			"name": "Alcoholism||denial140",
+			"action": "create",
+			"timestamp": "2024-11-07T16:27:06.425Z"
+		},
+		{
+			"id": 907,
+			"userId": "261983800429510658",
+			"model": "Completion",
+			"recordId": "60698",
+			"name": "Just Vibin'||nameless, Framzo",
+			"action": "create",
+			"timestamp": "2024-11-07T18:38:44.915Z"
+		},
+		{
+			"id": 908,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60670",
+			"name": "SuperSOLOable||Possessed",
+			"action": "update",
+			"timestamp": "2024-11-07T20:01:17.293Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 909,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60675",
+			"name": "Olievenhoutbosch||GreenPower, Lucco, Guck, LeJusDOrange",
+			"action": "update",
+			"timestamp": "2024-11-07T20:01:57.450Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 910,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60676",
+			"name": "'Not' Centurion||Men in Black",
+			"action": "update",
+			"timestamp": "2024-11-07T20:02:39.285Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 911,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60677",
+			"name": "An Idol||Sierra",
+			"action": "update",
+			"timestamp": "2024-11-07T20:04:53.457Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 912,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60678",
+			"name": "Professional Group||Aaron Kitty Boiii",
+			"action": "update",
+			"timestamp": "2024-11-07T20:06:06.475Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 913,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60679",
+			"name": "Praetorian New Ones||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-07T20:06:22.307Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 914,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60680",
+			"name": "Color Square Madness||Aaron Kitty Boiii",
+			"action": "update",
+			"timestamp": "2024-11-07T20:06:35.675Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 915,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60682",
+			"name": "Simplifier||Termet",
+			"action": "update",
+			"timestamp": "2024-11-07T20:08:13.903Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 916,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60683",
+			"name": "One Iconic Army||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-07T20:10:18.182Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 917,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60684",
+			"name": "Solo Madness||tactualdwarf519",
+			"action": "update",
+			"timestamp": "2024-11-07T20:10:42.335Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 918,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60685",
+			"name": "Doringkloof||Men in Black",
+			"action": "update",
+			"timestamp": "2024-11-07T20:11:13.624Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 919,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60686",
+			"name": "A Koopa's Favorite Modules||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-07T20:20:44.341Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 920,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60699",
+			"name": "ÜberKlax Endurance||Faith",
+			"action": "create",
+			"timestamp": "2024-11-07T21:52:19.065Z"
+		},
+		{
+			"id": 921,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60700",
+			"name": "Oompa Loompa Boon Poppycock||denial140",
+			"action": "create",
+			"timestamp": "2024-11-07T23:39:45.182Z"
+		},
+		{
+			"id": 922,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60701",
+			"name": "P e d r o||Faith",
+			"action": "create",
+			"timestamp": "2024-11-08T03:12:09.878Z"
+		},
+		{
+			"id": 923,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60702",
+			"name": "17 Again||tactualdwarf519",
+			"action": "create",
+			"timestamp": "2024-11-08T03:12:47.010Z"
+		},
+		{
+			"id": 924,
+			"userId": "234733182442799104",
+			"model": "Completion",
+			"recordId": "60703",
+			"name": "Tsundere||Danielstigman, Crazycaleb, Kugel",
+			"action": "create",
+			"timestamp": "2024-11-08T05:45:02.151Z"
+		},
+		{
+			"id": 925,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60704",
+			"name": "A Rule-Seeded Set||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-11-08T07:02:14.125Z"
+		},
+		{
+			"id": 926,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59403",
+			"name": "CentuRYAN||denial140",
+			"action": "update",
+			"timestamp": "2024-11-08T22:59:28.519Z",
+			"before": {
+				"time": 1954.62,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=f50db983f44487e4ccc775f12583d509b15079c4;bomb=KB9KC2"
+				]
+			},
+			"after": {
+				"time": 7094.92,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=f1eea12ca1a5f3f32131c4ed19e0357dcabb1c0a;bomb=HL1BA3"
+				]
+			}
+		},
+		{
+			"id": 927,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60687",
+			"name": "CentuRYAN||denial140",
+			"action": "delete",
+			"timestamp": "2024-11-08T22:59:28.529Z",
+			"before": {
+				"id": 60687,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 7094.92,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=f1eea12ca1a5f3f32131c4ed19e0357dcabb1c0a;bomb=HL1BA3"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-05T15:48:52.396Z",
+				"missionId": 9686,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 928,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59202",
+			"name": "Just Vibin'||denial140",
+			"action": "update",
+			"timestamp": "2024-11-08T23:00:35.775Z",
+			"before": {
+				"time": 1686.06,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=6dbda1f8c8b3993e07d030d289486bfd0ace704e;bomb=7G7QZ8",
+					"https://www.youtube.com/watch?v=wftePZ1iKn8"
+				]
+			},
+			"after": {
+				"time": 1943.39,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=632a25b57c3b92cc66c180425896ce56ddc7f4cb",
+					"https://youtu.be/XN7fd3hktQo"
+				]
+			}
+		},
+		{
+			"id": 929,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60688",
+			"name": "Just Vibin'||denial140",
+			"action": "delete",
+			"timestamp": "2024-11-08T23:00:35.783Z",
+			"before": {
+				"id": 60688,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 1943.39,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=632a25b57c3b92cc66c180425896ce56ddc7f4cb",
+					"https://youtu.be/XN7fd3hktQo"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-06T02:36:35.449Z",
+				"missionId": 9422,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 930,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60689",
+			"name": "Verbal Madness||Crazycaleb",
+			"action": "update",
+			"timestamp": "2024-11-08T23:00:50.033Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 931,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60690",
+			"name": "BlvdBroken's Bomb of Bangers (Climb)||Kugel, Termet, AzaFTW",
+			"action": "update",
+			"timestamp": "2024-11-08T23:01:06.849Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 932,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60705",
+			"name": "Centurion||denial140",
+			"action": "create",
+			"timestamp": "2024-11-09T01:08:09.922Z"
+		},
+		{
+			"id": 933,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60706",
+			"name": "asdfghjkl||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-11-09T04:35:43.748Z"
+		},
+		{
+			"id": 934,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10733",
+			"name": "Don't Break the Chain!",
+			"action": "update",
+			"timestamp": "2024-11-09T09:49:45.130Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 7085,
+								"pools": [
+									{ "count": 1, "modules": ["GSCatchMeIfYouCan"] },
+									{ "count": 1, "modules": ["DiophantineEquations"] },
+									{ "count": 1, "modules": ["disorderedKeys"] },
+									{ "count": 1, "modules": ["DrDoctorModule"] },
+									{ "count": 1, "modules": ["bigegg"] },
+									{ "count": 1, "modules": ["encryptionBingo"] },
+									{ "count": 1, "modules": ["exoplanets"] },
+									{ "count": 1, "modules": ["gameChangerModule"] },
+									{ "count": 1, "modules": ["GhostModule"] },
+									{ "count": 1, "modules": ["xelGraphIdentification"] },
+									{ "count": 1, "modules": ["HexamazeModule"] },
+									{ "count": 1, "modules": ["inupiaqNumerals"] },
+									{ "count": 1, "modules": ["lgndLombaxCubes"] },
+									{ "count": 1, "modules": ["manualMalady"] },
+									{ "count": 1, "modules": ["Needy Math"] },
+									{ "count": 1, "modules": ["myMom"] },
+									{ "count": 1, "modules": ["novemberModule"] },
+									{ "count": 1, "modules": ["nim"] },
+									{ "count": 1, "modules": ["NotKanjiModule"] },
+									{ "count": 1, "modules": ["notnot"] },
+									{ "count": 1, "modules": ["NotWhosOnFirst"] },
+									{ "count": 1, "modules": ["ObscurdleModule"] },
+									{ "count": 1, "modules": ["offKeys"] },
+									{ "count": 1, "modules": ["OnlyConnectModule"] },
+									{ "count": 1, "modules": ["OrientationCube"] },
+									{ "count": 1, "modules": ["Painting"] },
+									{ "count": 1, "modules": ["RedNeedy"] },
+									{ "count": 1, "modules": ["romanArtModule"] },
+									{ "count": 1, "modules": ["SaimoePad"] },
+									{ "count": 1, "modules": ["scrabbleScramble"] },
+									{ "count": 1, "modules": ["serialWires"] },
+									{ "count": 1, "modules": ["Simon"] },
+									{ "count": 1, "modules": ["slightGibberishTwistModule"] },
+									{ "count": 1, "modules": ["stainRemoval"] },
+									{ "count": 1, "modules": ["starmap_reconstruction"] },
+									{ "count": 1, "modules": ["subtractNauseam"] },
+									{ "count": 1, "modules": ["superparsing"] },
+									{ "count": 1, "modules": ["symbolicCoordinates"] },
+									{ "count": 1, "modules": ["symbolicPasswordModule"] },
+									{ "count": 1, "modules": ["synonyms"] },
+									{ "count": 1, "modules": ["tWords"] },
+									{ "count": 1, "modules": ["TACModule"] },
+									{ "count": 1, "modules": ["Tangrams"] },
+									{ "count": 1, "modules": ["tapFast"] },
+									{ "count": 1, "modules": ["theTeardrop"] },
+									{ "count": 1, "modules": ["transmissionTransposition"] },
+									{ "count": 1, "modules": ["yesandno"] }
+								],
+								"modules": 47,
+								"strikes": 4,
+								"widgets": 5
+							},
+							"where": { "id": 14694 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 935,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10733",
+			"name": "Don't Break the Chain!",
+			"action": "update",
+			"timestamp": "2024-11-09T09:49:45.147Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=b0ee03935d16ccb86990697c84233e7355b1663c" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=d45869ec91c56b62e2c68503565476edd7002989" }
+		},
+		{
+			"id": 936,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10733",
+			"name": "Don't Break the Chain!",
+			"action": "update",
+			"timestamp": "2024-11-09T09:50:48.126Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 937,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10734",
+			"name": "Chain Continues",
+			"action": "update",
+			"timestamp": "2024-11-09T09:50:49.120Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 938,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10735",
+			"name": "Strike a Chain",
+			"action": "update",
+			"timestamp": "2024-11-09T09:50:49.969Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 939,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10736",
+			"name": "Chain's End",
+			"action": "update",
+			"timestamp": "2024-11-09T09:50:50.755Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 940,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10762",
+			"name": "Baka, Baka, Baka",
+			"action": "update",
+			"timestamp": "2024-11-09T09:50:52.341Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 941,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10768",
+			"name": "What The Boss - Bossadder Goes Forth",
+			"action": "update",
+			"timestamp": "2024-11-09T09:51:02.154Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 942,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10769",
+			"name": "Major Update",
+			"action": "update",
+			"timestamp": "2024-11-09T09:51:03.234Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 943,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10772",
+			"name": "Kugel's Mixed Favorite",
+			"action": "update",
+			"timestamp": "2024-11-09T09:51:04.340Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 944,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10773",
+			"name": "Everyone's Least Favorite Boss",
+			"action": "update",
+			"timestamp": "2024-11-09T09:51:05.599Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 945,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10775",
+			"name": "Nightmare Mode: Savor the Moment",
+			"action": "update",
+			"timestamp": "2024-11-09T09:51:11.555Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 946,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10776",
+			"name": "Selectomaniac",
+			"action": "update",
+			"timestamp": "2024-11-09T09:51:12.342Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 947,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10778",
+			"name": "The Definition of Insanity",
+			"action": "update",
+			"timestamp": "2024-11-09T09:51:14.363Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 948,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60691",
+			"name": "Gotta Be Fast||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-09T12:58:40.946Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 949,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60692",
+			"name": "A Sensible Challenge||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-09T12:58:54.942Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 950,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60693",
+			"name": "Just Vibin'||Zappyjro",
+			"action": "update",
+			"timestamp": "2024-11-09T12:59:22.970Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 951,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60695",
+			"name": "Just Vibin'||Framzo, nameless",
+			"action": "update",
+			"timestamp": "2024-11-09T13:00:30.213Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 952,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60694",
+			"name": "A Sensible Challenge||tactualdwarf519",
+			"action": "update",
+			"timestamp": "2024-11-09T13:01:18.849Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 953,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60696",
+			"name": "Thank Goodness You're Here!||AzaFTW, Burniel, Danielstigman",
+			"action": "update",
+			"timestamp": "2024-11-09T13:03:02.558Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 954,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60707",
+			"name": "Prisencolinensinainciusol||BladePL",
+			"action": "create",
+			"timestamp": "2024-11-09T14:38:36.946Z"
+		},
+		{
+			"id": 955,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60681",
+			"name": "Core's Entrance||Awesome7285, weird, Sierra",
+			"action": "update",
+			"timestamp": "2024-11-09T16:08:13.164Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 956,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60681",
+			"name": "Core's Entrance||Awesome7285, weird, Sierra",
+			"action": "update",
+			"timestamp": "2024-11-09T16:08:48.916Z",
+			"before": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=4af48bf3e91b5e6f2538fa92969f6da6887dcb10;bomb=XP2WA7",
+					"https://www.twitch.tv/videos/2293479044",
+					"https://youtu.be/vrzqFNSOSDk",
+					"https://youtu.be/qYfx3zk702s"
+				]
+			},
+			"after": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=4af48bf3e91b5e6f2538fa92969f6da6887dcb10;bomb=XP2WA7",
+					"https://www.twitch.tv/videos/2293479044",
+					"https://youtu.be/vrzqFNSOSDk",
+					"https://www.youtube.com/watch?v=KOk5kIG0qFI"
+				]
+			}
+		},
+		{
+			"id": 957,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "9927",
+			"name": "Deuxturion",
+			"action": "update",
+			"timestamp": "2024-11-09T16:12:15.901Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 9600,
+								"pools": [
+									{ "count": 1, "modules": ["punctuationMarks"] },
+									{ "count": 3, "modules": ["OneDimensionalMaze"] },
+									{ "count": 1, "modules": ["spwiz3DMaze"] },
+									{ "count": 1, "modules": ["7"] },
+									{ "count": 1, "modules": ["lgndAudioMorse"] },
+									{ "count": 2, "modules": ["ksmBadugi"] },
+									{ "count": 1, "modules": ["BartendingModule"] },
+									{ "count": 1, "modules": ["BigCircle"] },
+									{ "count": 2, "modules": ["binaryTree"] },
+									{ "count": 1, "modules": ["BitOps"] },
+									{ "count": 1, "modules": ["booleanVennModule"] },
+									{ "count": 1, "modules": ["booleanWires"] },
+									{ "count": 1, "modules": ["borderedKeys"] },
+									{ "count": 1, "modules": ["burgerAlarm"] },
+									{ "count": 1, "modules": ["ChessModule"] },
+									{ "count": 2, "modules": ["coffeebucks"] },
+									{ "count": 1, "modules": ["ColorMorseModule"] },
+									{ "count": 1, "modules": ["colorfulDials"] },
+									{ "count": 1, "modules": ["CruelPianoKeys"] },
+									{ "count": 1, "modules": ["cube"] },
+									{ "count": 1, "modules": ["deckOfManyThings"] },
+									{ "count": 1, "modules": ["digitalDials"] },
+									{ "count": 1, "modules": ["dungeon"] },
+									{ "count": 1, "modules": ["dungeon2"] },
+									{ "count": 2, "modules": ["EmotiguyIdentification"] },
+									{ "count": 1, "modules": ["fastMath"] },
+									{ "count": 1, "modules": ["MemoryV2"] },
+									{ "count": 1, "modules": ["GameOfLifeCruel"] },
+									{ "count": 1, "modules": ["greenCipher"] },
+									{ "count": 1, "modules": ["heraldry"] },
+									{ "count": 1, "modules": ["hieroglyphics"] },
+									{ "count": 1, "modules": ["ksmHighScore"] },
+									{ "count": 1, "modules": ["jewelVault"] },
+									{ "count": 1, "modules": ["KanjiModule"] },
+									{ "count": 1, "modules": ["KiloTalk"] },
+									{ "count": 1, "modules": ["KudosudokuModule"] },
+									{ "count": 1, "modules": ["LEDEnc"] },
+									{ "count": 1, "modules": ["LEDEnc"] },
+									{ "count": 1, "modules": ["Listening"] },
+									{ "count": 1, "modules": ["lgndLombaxCubes"] },
+									{ "count": 1, "modules": ["londonUnderground"] },
+									{ "count": 1, "modules": ["loopover"] },
+									{ "count": 1, "modules": ["Mastermind Cruel"] },
+									{ "count": 1, "modules": ["MatrixQuiz"] },
+									{ "count": 1, "modules": ["maze3"] },
+									{ "count": 1, "modules": ["monsplodeFight"] },
+									{ "count": 1, "modules": ["moon"] },
+									{ "count": 1, "modules": ["MoreCode"] },
+									{ "count": 1, "modules": ["mcdNatures"] },
+									{ "count": 1, "modules": ["NotKeypad"] },
+									{ "count": 1, "modules": ["notnot"] },
+									{ "count": 1, "modules": ["NotWireSequence"] },
+									{ "count": 1, "modules": ["NotWiresword"] },
+									{ "count": 2, "modules": ["orangeCipher"] },
+									{ "count": 1, "modules": ["palindromes"] },
+									{ "count": 2, "modules": ["passportControl"] },
+									{ "count": 1, "modules": ["quaternions"] },
+									{ "count": 1, "modules": ["robotProgramming"] },
+									{ "count": 1, "modules": ["sequencesModule"] },
+									{ "count": 1, "modules": ["sevenChooseFour"] },
+									{ "count": 1, "modules": ["SimonSendsModule"] },
+									{ "count": 1, "modules": ["SimonSingsModule"] },
+									{ "count": 1, "modules": ["SimonSpinsModule"] },
+									{ "count": 1, "modules": ["simonStops"] },
+									{ "count": 1, "modules": ["SpotTheDifference"] },
+									{ "count": 1, "modules": ["StandardCrazyTalk"] },
+									{ "count": 1, "modules": ["stopwatch"] },
+									{ "count": 1, "modules": ["SuperlogicModule"] },
+									{ "count": 1, "modules": ["TenButtonColorCode"] },
+									{ "count": 1, "modules": ["TennisModule"] },
+									{ "count": 1, "modules": ["WorldsLargestButton"] },
+									{ "count": 2, "modules": ["XRayModule"] }
+								],
+								"modules": 81,
+								"strikes": 10,
+								"widgets": 5
+							},
+							"where": { "id": 13440 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 958,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60708",
+			"name": "Tenth Day of Christmas||AzaFTW, Termet",
+			"action": "create",
+			"timestamp": "2024-11-09T16:21:39.779Z"
+		},
+		{
+			"id": 959,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60709",
+			"name": "Enemy||Sierra",
+			"action": "create",
+			"timestamp": "2024-11-09T16:29:57.372Z"
+		},
+		{
+			"id": 960,
+			"userId": "189932350791090176",
+			"model": "Mission",
+			"recordId": "10791",
+			"name": "[[UPDATE]] Major Update",
+			"action": "create",
+			"timestamp": "2024-11-09T18:26:19.780Z"
+		},
+		{
+			"id": 961,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60710",
+			"name": "Nightmare Mode: Savor the Moment||Faith",
+			"action": "create",
+			"timestamp": "2024-11-09T19:58:05.986Z"
+		},
+		{
+			"id": 962,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60697",
+			"name": "Alcoholism||denial140",
+			"action": "update",
+			"timestamp": "2024-11-09T20:19:04.395Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 963,
+			"userId": "488806494872272898",
+			"model": "Completion",
+			"recordId": "60711",
+			"name": "Nightmare Mode: Savor the Moment||Men in Black",
+			"action": "create",
+			"timestamp": "2024-11-09T21:15:33.546Z"
+		},
+		{
+			"id": 964,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60712",
+			"name": "Baka, Baka, Baka||Kugel",
+			"action": "create",
+			"timestamp": "2024-11-09T22:38:55.819Z"
+		},
+		{
+			"id": 965,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60713",
+			"name": "Nightmare Mode: Savor the Moment||Kugel",
+			"action": "create",
+			"timestamp": "2024-11-09T23:56:57.926Z"
+		},
+		{
+			"id": 966,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60714",
+			"name": "Nightmare Mode: Savor the Moment||Faith, detective1, Men in Black",
+			"action": "create",
+			"timestamp": "2024-11-10T02:27:33.461Z"
+		},
+		{
+			"id": 967,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60715",
+			"name": "Cerberus||denial140",
+			"action": "create",
+			"timestamp": "2024-11-10T04:09:00.327Z"
+		},
+		{
+			"id": 968,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60699",
+			"name": "ÜberKlax Endurance||Faith",
+			"action": "update",
+			"timestamp": "2024-11-10T11:19:48.226Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 969,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10769",
+			"name": "Major Update",
+			"action": "update",
+			"timestamp": "2024-11-10T11:20:36.896Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=b21c46d3a3a5f6988d00c077e4e4b589b580d2f5" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 3720,
+							"pools": [
+								{ "count": 1, "modules": ["AdjacentLettersModule"] },
+								{ "count": 1, "modules": ["TheArena"] },
+								{ "count": 1, "modules": ["babaIsWho"] },
+								{ "count": 1, "modules": ["Binary"] },
+								{ "count": 1, "modules": ["boggle"] },
+								{ "count": 1, "modules": ["boxing"] },
+								{ "count": 1, "modules": ["buttonGrid"] },
+								{ "count": 1, "modules": ["cellLab"] },
+								{ "count": 1, "modules": ["CoordinatesModule"] },
+								{ "count": 1, "modules": ["TheDials"] },
+								{ "count": 1, "modules": ["DIWindow"] },
+								{ "count": 1, "modules": ["elderFuthark"] },
+								{ "count": 1, "modules": ["encryptionBingo"] },
+								{ "count": 1, "modules": ["flashingCircles"] },
+								{ "count": 1, "modules": ["FloorLights"] },
+								{ "count": 1, "modules": ["GlitchedButtonModule"] },
+								{ "count": 1, "modules": ["graphicMemory"] },
+								{ "count": 1, "modules": ["GrayButtonModule"] },
+								{ "count": 1, "modules": ["handTurkey"] },
+								{ "count": 1, "modules": ["IntegerTrees"] },
+								{ "count": 1, "modules": ["KeypadMaze"] },
+								{ "count": 1, "modules": ["LEGOModule"] },
+								{ "count": 1, "modules": ["letterMath"] },
+								{ "count": 1, "modules": ["Logic"] },
+								{ "count": 1, "modules": ["metamem"] },
+								{ "count": 1, "modules": ["moduleListening"] },
+								{ "count": 1, "modules": ["ModuleMaze"] },
+								{ "count": 1, "modules": ["MorseV2"] },
+								{ "count": 1, "modules": ["NandNs"] },
+								{ "count": 1, "modules": ["organizationModule"] },
+								{ "count": 1, "modules": ["pigpenRotations"] },
+								{ "count": 1, "modules": ["poisonedGoblets"] },
+								{ "count": 1, "modules": ["presidentialElections"] },
+								{ "count": 1, "modules": ["purpleArrowsModule"] },
+								{ "count": 1, "modules": ["R4YRecoloredSwitches"] },
+								{ "count": 1, "modules": ["RecolourFlashModule"] },
+								{ "count": 1, "modules": ["QuickArithmetic"] },
+								{ "count": 1, "modules": ["QLModule"] },
+								{ "count": 1, "modules": ["rgbChess"] },
+								{ "count": 1, "modules": ["PasswordV2"] },
+								{ "count": 1, "modules": ["scavengerHunt"] },
+								{ "count": 1, "modules": ["ShapeFillModule"] },
+								{ "count": 1, "modules": ["SimonSmiles"] },
+								{ "count": 1, "modules": ["SymbolCycleModule"] },
+								{ "count": 1, "modules": ["tasqueManaging"] },
+								{ "count": 1, "modules": ["unfairCipher"] },
+								{ "count": 1, "modules": ["yetAnotherKeypad"] }
+							],
+							"modules": 47,
+							"strikes": 4,
+							"widgets": 5
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=dc7cb32a3ac0e263b5d647d69048a142e4cc0f27"
+			}
+		},
+		{
+			"id": 970,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10791",
+			"name": "[[UPDATE]] Major Update",
+			"action": "delete",
+			"timestamp": "2024-11-10T11:20:36.920Z",
+			"before": {
+				"id": 10791,
+				"name": "[[UPDATE]] Major Update",
+				"notes": null,
+				"authors": ["Asew"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=dc7cb32a3ac0e263b5d647d69048a142e4cc0f27",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_2991409494_majorUpdate",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-11-09T18:26:18.583Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "189932350791090176",
+				"designedForTP": false,
+				"missionPackId": 571
+			}
+		},
+		{
+			"id": 971,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60700",
+			"name": "Oompa Loompa Boon Poppycock||denial140",
+			"action": "update",
+			"timestamp": "2024-11-10T11:34:48.802Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 972,
+			"userId": "488806494872272898",
+			"model": "Completion",
+			"recordId": "60716",
+			"name": "ÜberKlax Endurance||Men in Black, Ayeka, Masked Mystery",
+			"action": "create",
+			"timestamp": "2024-11-11T05:04:39.256Z"
+		},
+		{
+			"id": 973,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60698",
+			"name": "Just Vibin'||nameless, Framzo",
+			"action": "update",
+			"timestamp": "2024-11-11T12:54:11.089Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 974,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60701",
+			"name": "P e d r o||Faith",
+			"action": "update",
+			"timestamp": "2024-11-11T12:54:30.309Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 975,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60702",
+			"name": "17 Again||tactualdwarf519",
+			"action": "update",
+			"timestamp": "2024-11-11T12:55:16.355Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 976,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60703",
+			"name": "Tsundere||Danielstigman, Crazycaleb, Kugel",
+			"action": "update",
+			"timestamp": "2024-11-11T12:58:52.863Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 977,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60704",
+			"name": "A Rule-Seeded Set||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-11T12:59:44.771Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 978,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59481",
+			"name": "Centurion||denial140",
+			"action": "update",
+			"timestamp": "2024-11-11T13:00:52.948Z",
+			"before": {
+				"time": 1101.83,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=403833b5ac8107f1d6086dc9f1690f3742084bf8;bomb=BV3BH3"
+				]
+			},
+			"after": {
+				"time": 2151.95,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=a27de3d770f1f2088ec416c90d7af7ba6c8a1231;bomb=PU1VZ9"
+				]
+			}
+		},
+		{
+			"id": 979,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60705",
+			"name": "Centurion||denial140",
+			"action": "delete",
+			"timestamp": "2024-11-11T13:00:53.007Z",
+			"before": {
+				"id": 60705,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 2151.95,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=a27de3d770f1f2088ec416c90d7af7ba6c8a1231;bomb=PU1VZ9"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-09T01:08:04.505Z",
+				"missionId": 9861,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 980,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60706",
+			"name": "asdfghjkl||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-11T13:01:42.077Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 981,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60707",
+			"name": "Prisencolinensinainciusol||BladePL",
+			"action": "update",
+			"timestamp": "2024-11-11T13:03:02.543Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 982,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60708",
+			"name": "Tenth Day of Christmas||AzaFTW, Termet",
+			"action": "update",
+			"timestamp": "2024-11-11T13:05:22.280Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 983,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60709",
+			"name": "Enemy||Sierra",
+			"action": "update",
+			"timestamp": "2024-11-11T13:06:14.085Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 984,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60710",
+			"name": "Nightmare Mode: Savor the Moment||Faith",
+			"action": "update",
+			"timestamp": "2024-11-11T13:08:11.268Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 985,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60711",
+			"name": "Nightmare Mode: Savor the Moment||Men in Black",
+			"action": "update",
+			"timestamp": "2024-11-11T13:08:12.665Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 986,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60713",
+			"name": "Nightmare Mode: Savor the Moment||Kugel",
+			"action": "update",
+			"timestamp": "2024-11-11T13:08:13.835Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 987,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60714",
+			"name": "Nightmare Mode: Savor the Moment||Faith, detective1, Men in Black",
+			"action": "update",
+			"timestamp": "2024-11-11T13:08:15.103Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 988,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60712",
+			"name": "Baka, Baka, Baka||Kugel",
+			"action": "update",
+			"timestamp": "2024-11-11T13:09:46.420Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 989,
+			"userId": "725302560432324637",
+			"model": "Completion",
+			"recordId": "60717",
+			"name": "QN!: FCDT||Cookina",
+			"action": "create",
+			"timestamp": "2024-11-11T16:12:36.929Z"
+		},
+		{
+			"id": 990,
+			"userId": "261983800429510658",
+			"model": "Completion",
+			"recordId": "60718",
+			"name": ":((=||nameless, Framzo",
+			"action": "create",
+			"timestamp": "2024-11-11T19:14:09.857Z"
+		},
+		{
+			"id": 991,
+			"userId": "527988470929686560",
+			"model": "Completion",
+			"recordId": "60719",
+			"name": "Everyone's Least Favorite Boss||BCMGF1137/19#5398",
+			"action": "create",
+			"timestamp": "2024-11-11T21:50:39.944Z"
+		},
+		{
+			"id": 992,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60720",
+			"name": "QN!: FCDT||Faith, Sierra",
+			"action": "create",
+			"timestamp": "2024-11-11T22:34:08.653Z"
+		},
+		{
+			"id": 993,
+			"userId": "589237691691040798",
+			"model": "Completion",
+			"recordId": "60721",
+			"name": "Easy Challenge||StalledStorm775, Masked Mystery, LitAiden",
+			"action": "create",
+			"timestamp": "2024-11-12T00:40:36.755Z"
+		},
+		{
+			"id": 994,
+			"userId": "628939105480474636",
+			"model": "Completion",
+			"recordId": "60722",
+			"name": "Easy Challenge||TheBigBadBull, Aaron Kitty Boiii",
+			"action": "create",
+			"timestamp": "2024-11-12T03:50:18.436Z"
+		},
+		{
+			"id": 995,
+			"userId": "980292547823931475",
+			"model": "Completion",
+			"recordId": "60723",
+			"name": "Easy Challenge||TylerY2992, Masked Mystery, LitAiden",
+			"action": "create",
+			"timestamp": "2024-11-13T01:43:38.153Z"
+		},
+		{
+			"id": 996,
+			"userId": "337934133751840769",
+			"model": "Completion",
+			"recordId": "60724",
+			"name": "Umbra Moruka's Final Moment||Benjamin",
+			"action": "create",
+			"timestamp": "2024-11-13T10:08:25.368Z"
+		},
+		{
+			"id": 997,
+			"userId": "455035517872898050",
+			"model": "Completion",
+			"recordId": "60725",
+			"name": "Boss Module Endurance||_Play_",
+			"action": "create",
+			"timestamp": "2024-11-13T12:45:06.023Z"
+		},
+		{
+			"id": 998,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60715",
+			"name": "Cerberus||denial140",
+			"action": "update",
+			"timestamp": "2024-11-13T12:55:12.211Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 999,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60716",
+			"name": "ÜberKlax Endurance||Men in Black, Ayeka, Masked Mystery",
+			"action": "update",
+			"timestamp": "2024-11-13T12:55:26.660Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1000,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60717",
+			"name": "QN!: FCDT||Cookina",
+			"action": "update",
+			"timestamp": "2024-11-13T12:55:54.307Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1001,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60718",
+			"name": ":((=||nameless, Framzo",
+			"action": "update",
+			"timestamp": "2024-11-13T13:10:19.743Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1002,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60719",
+			"name": "Everyone's Least Favorite Boss||BCMGF1137/19#5398",
+			"action": "update",
+			"timestamp": "2024-11-13T13:17:35.377Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 1003,
+			"userId": "455035517872898050",
+			"model": "Completion",
+			"recordId": "60726",
+			"name": "SoulOrg Endurance||_Play_",
+			"action": "create",
+			"timestamp": "2024-11-13T14:14:33.080Z"
+		},
+		{
+			"id": 1004,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60727",
+			"name": "Boss Module Endurance||Termet",
+			"action": "create",
+			"timestamp": "2024-11-13T15:57:30.847Z"
+		},
+		{
+			"id": 1005,
+			"userId": "104464697775882240",
+			"model": "Completion",
+			"recordId": "60728",
+			"name": "ÜberKlax Endurance||Framzo, nameless",
+			"action": "create",
+			"timestamp": "2024-11-13T19:36:11.204Z"
+		},
+		{
+			"id": 1006,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60729",
+			"name": "Kugel's Mixed Favorite||Kugel",
+			"action": "create",
+			"timestamp": "2024-11-13T23:30:50.004Z"
+		},
+		{
+			"id": 1007,
+			"userId": "594991798045114389",
+			"model": "Completion",
+			"recordId": "60730",
+			"name": "SoulOrg Endurance||Masked Mystery, Ayeka",
+			"action": "create",
+			"timestamp": "2024-11-13T23:38:51.438Z"
+		},
+		{
+			"id": 1008,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60731",
+			"name": "Silence Madness||AzaFTW",
+			"action": "create",
+			"timestamp": "2024-11-14T01:17:22.241Z"
+		},
+		{
+			"id": 1009,
+			"userId": "628939105480474636",
+			"model": "Completion",
+			"recordId": "60732",
+			"name": "ÜberKlax Endurance||TheBigBadBull, Aaron Kitty Boiii, Kugel",
+			"action": "create",
+			"timestamp": "2024-11-14T05:45:32.931Z"
+		},
+		{
+			"id": 1010,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60733",
+			"name": "Eldoraigne||denial140",
+			"action": "create",
+			"timestamp": "2024-11-14T06:17:19.577Z"
+		},
+		{
+			"id": 1011,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10659",
+			"name": "P e d r o",
+			"action": "update",
+			"timestamp": "2024-11-14T08:13:06.655Z",
+			"before": {
+				"name": "P e d r o",
+				"logfile": "https://ktane.timwi.de/lfa#file=74986707519ca13614311905b8bd9e7d7c872539"
+			},
+			"after": {
+				"name": "Pedro",
+				"logfile": "https://ktane.timwi.de/lfa#file=5b902db998d1d14fa18fa76ee8c0aca39b993196"
+			}
+		},
+		{
+			"id": 1012,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10659",
+			"name": "Pedro",
+			"action": "update",
+			"timestamp": "2024-11-14T08:13:45.161Z",
+			"before": { "inGameId": "mod_youro_mission_pack_P e d r o" },
+			"after": { "inGameId": "mod_youro_mission_pack_Pedro" }
+		},
+		{
+			"id": 1013,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10560",
+			"name": "M i g u e l",
+			"action": "update",
+			"timestamp": "2024-11-14T08:15:23.288Z",
+			"before": {
+				"name": "M i g u e l",
+				"logfile": "https://ktane.timwi.de/lfa#file=40bbfe8c837f29f70d84ba895e33eac7d836fab4",
+				"inGameId": "mod_youro_mission_pack_M i g u e l"
+			},
+			"after": {
+				"name": "Miguel",
+				"logfile": "https://ktane.timwi.de/lfa#file=5b902db998d1d14fa18fa76ee8c0aca39b993196",
+				"inGameId": "mod_youro_mission_pack_Miguel"
+			}
+		},
+		{
+			"id": 1014,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10561",
+			"name": "R a f a e l",
+			"action": "update",
+			"timestamp": "2024-11-14T08:16:20.827Z",
+			"before": {
+				"name": "R a f a e l",
+				"logfile": "https://ktane.timwi.de/lfa#file=40bbfe8c837f29f70d84ba895e33eac7d836fab4",
+				"inGameId": "mod_youro_mission_pack_R a f a e l"
+			},
+			"after": {
+				"name": "Rafael",
+				"logfile": "https://ktane.timwi.de/lfa#file=5b902db998d1d14fa18fa76ee8c0aca39b993196",
+				"inGameId": "mod_youro_mission_pack_Rafael"
+			}
+		},
+		{
+			"id": 1015,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10559",
+			"name": "J u a n",
+			"action": "update",
+			"timestamp": "2024-11-14T08:17:20.522Z",
+			"before": {
+				"name": "J u a n",
+				"logfile": "https://ktane.timwi.de/lfa#file=40bbfe8c837f29f70d84ba895e33eac7d836fab4",
+				"inGameId": "mod_youro_mission_pack_J u a n"
+			},
+			"after": {
+				"name": "Juan",
+				"logfile": "https://ktane.timwi.de/lfa#file=5b902db998d1d14fa18fa76ee8c0aca39b993196",
+				"inGameId": "mod_youro_mission_pack_Juan"
+			}
+		},
+		{
+			"id": 1016,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60720",
+			"name": "QN!: FCDT||Faith, Sierra",
+			"action": "update",
+			"timestamp": "2024-11-14T08:18:33.105Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1017,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60721",
+			"name": "Easy Challenge||StalledStorm775, Masked Mystery, LitAiden",
+			"action": "update",
+			"timestamp": "2024-11-14T08:20:33.213Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1018,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60722",
+			"name": "Easy Challenge||TheBigBadBull, Aaron Kitty Boiii",
+			"action": "update",
+			"timestamp": "2024-11-14T08:20:56.633Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1019,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60723",
+			"name": "Easy Challenge||TylerY2992, Masked Mystery, LitAiden",
+			"action": "update",
+			"timestamp": "2024-11-14T08:23:02.277Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1020,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60724",
+			"name": "Umbra Moruka's Final Moment||Benjamin",
+			"action": "update",
+			"timestamp": "2024-11-14T08:23:47.923Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 1021,
+			"userId": "455035517872898050",
+			"model": "Completion",
+			"recordId": "60734",
+			"name": "ÜberKlax Endurance||_Play_",
+			"action": "create",
+			"timestamp": "2024-11-14T12:28:04.159Z"
+		},
+		{
+			"id": 1022,
+			"userId": "485774478282981376",
+			"model": "Mission",
+			"recordId": "10792",
+			"name": "7-Segmented Madness",
+			"action": "create",
+			"timestamp": "2024-11-14T14:24:18.224Z"
+		},
+		{
+			"id": 1023,
+			"userId": "485774478282981376",
+			"model": "Mission",
+			"recordId": "10793",
+			"name": "Pipe Dream",
+			"action": "create",
+			"timestamp": "2024-11-14T14:26:20.945Z"
+		},
+		{
+			"id": 1024,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60725",
+			"name": "Boss Module Endurance||_Play_",
+			"action": "update",
+			"timestamp": "2024-11-14T18:42:59.982Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1025,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60726",
+			"name": "SoulOrg Endurance||_Play_",
+			"action": "update",
+			"timestamp": "2024-11-14T18:43:13.366Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1026,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60727",
+			"name": "Boss Module Endurance||Termet",
+			"action": "update",
+			"timestamp": "2024-11-14T18:44:47.179Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1027,
+			"userId": "261983800429510658",
+			"model": "Completion",
+			"recordId": "60735",
+			"name": "ÜberKlax Endurance||nameless, Framzo",
+			"action": "create",
+			"timestamp": "2024-11-14T20:00:53.015Z"
+		},
+		{
+			"id": 1028,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60728",
+			"name": "ÜberKlax Endurance||Framzo, nameless",
+			"action": "update",
+			"timestamp": "2024-11-14T22:16:14.031Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1029,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60729",
+			"name": "Kugel's Mixed Favorite||Kugel",
+			"action": "update",
+			"timestamp": "2024-11-14T22:16:38.058Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 1030,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60730",
+			"name": "SoulOrg Endurance||Masked Mystery, Ayeka",
+			"action": "update",
+			"timestamp": "2024-11-14T22:16:54.420Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1031,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60731",
+			"name": "Silence Madness||AzaFTW",
+			"action": "update",
+			"timestamp": "2024-11-14T22:17:55.583Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1032,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60732",
+			"name": "ÜberKlax Endurance||TheBigBadBull, Aaron Kitty Boiii, Kugel",
+			"action": "update",
+			"timestamp": "2024-11-14T22:18:06.708Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1033,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59723",
+			"name": "Eldoraigne||denial140",
+			"action": "update",
+			"timestamp": "2024-11-14T22:18:56.922Z",
+			"before": {
+				"time": 1336.15,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=91e0c0e98376013d17cc7be29ce9d722facd4376;bomb=1K7BM8"
+				]
+			},
+			"after": {
+				"time": 1647.96,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=8f2fac19bb82ec3f61985fcd368c31b86553e057;bomb=LM1SI2",
+					"https://youtu.be/OKMMeFIMLsg"
+				]
+			}
+		},
+		{
+			"id": 1034,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60733",
+			"name": "Eldoraigne||denial140",
+			"action": "delete",
+			"timestamp": "2024-11-14T22:18:56.932Z",
+			"before": {
+				"id": 60733,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 1647.96,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=8f2fac19bb82ec3f61985fcd368c31b86553e057;bomb=LM1SI2",
+					"https://youtu.be/OKMMeFIMLsg"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-14T06:17:07.812Z",
+				"missionId": 9881,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 1035,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60734",
+			"name": "ÜberKlax Endurance||_Play_",
+			"action": "update",
+			"timestamp": "2024-11-14T22:19:29.102Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1036,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60735",
+			"name": "ÜberKlax Endurance||nameless, Framzo",
+			"action": "update",
+			"timestamp": "2024-11-14T22:20:04.625Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1037,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60736",
+			"name": "Nightmare Mode: Savor the Moment||Benjamin, Bianca, Burniel",
+			"action": "create",
+			"timestamp": "2024-11-14T22:20:33.947Z"
+		},
+		{
+			"id": 1038,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60736",
+			"name": "Nightmare Mode: Savor the Moment||Benjamin, Bianca, Burniel",
+			"action": "update",
+			"timestamp": "2024-11-14T22:20:37.004Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1039,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59549",
+			"name": "Possibly Impossible||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-14T22:23:25.828Z",
+			"before": { "notes": "Pre-calculated solution" },
+			"after": { "notes": null }
+		},
+		{
+			"id": 1040,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10772",
+			"name": "Kugel's Mixed Favorite",
+			"action": "update",
+			"timestamp": "2024-11-14T22:25:47.683Z",
+			"before": {
+				"name": "Kugel's Mixed Favorite",
+				"logfile": "https://ktane.timwi.de/lfa#file=e3ac503127711218438824e0d4032ecadd3eceec"
+			},
+			"after": {
+				"name": "Kugel's Mixed Favorites",
+				"logfile": "https://ktane.timwi.de/lfa#file=6163de899772bc367e492db131ab45a0b12c7899"
+			}
+		},
+		{
+			"id": 1041,
+			"userId": "678178906871955473",
+			"model": "Completion",
+			"recordId": "60737",
+			"name": "ÜberKlax Endurance||StalledStorm775",
+			"action": "create",
+			"timestamp": "2024-11-14T23:33:26.087Z"
+		},
+		{
+			"id": 1042,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60738",
+			"name": "Uber Forget Me Not||denial140",
+			"action": "create",
+			"timestamp": "2024-11-15T04:43:17.985Z"
+		},
+		{
+			"id": 1043,
+			"userId": "594991798045114389",
+			"model": "Completion",
+			"recordId": "60739",
+			"name": "SoulOrg Endurance||Ayeka, Ekmek",
+			"action": "create",
+			"timestamp": "2024-11-15T07:16:14.006Z"
+		},
+		{
+			"id": 1044,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60737",
+			"name": "ÜberKlax Endurance||StalledStorm775",
+			"action": "update",
+			"timestamp": "2024-11-15T08:12:46.469Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1045,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59397",
+			"name": "Uber Forget Me Not||denial140",
+			"action": "update",
+			"timestamp": "2024-11-15T08:13:08.555Z",
+			"before": {
+				"time": 2294.29,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=756be4e8f2c2827da6488be2be76bfe6a7648616;bomb=R45XV1"
+				]
+			},
+			"after": {
+				"time": 6265.79,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=2e297235fcd58a02898b9fb2cd9acbaab8f30ff0",
+					"https://youtu.be/LINVLnRt_Lw"
+				]
+			}
+		},
+		{
+			"id": 1046,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60738",
+			"name": "Uber Forget Me Not||denial140",
+			"action": "delete",
+			"timestamp": "2024-11-15T08:13:08.563Z",
+			"before": {
+				"id": 60738,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 6265.79,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=2e297235fcd58a02898b9fb2cd9acbaab8f30ff0",
+					"https://youtu.be/LINVLnRt_Lw"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-15T04:43:03.819Z",
+				"missionId": 9411,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 1047,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60739",
+			"name": "SoulOrg Endurance||Ayeka, Ekmek",
+			"action": "update",
+			"timestamp": "2024-11-15T08:13:28.203Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1048,
+			"userId": "337934133751840769",
+			"model": "Completion",
+			"recordId": "60740",
+			"name": "Nightmare Mode: Savor the Moment||Benjamin, Bianca, Burniel",
+			"action": "create",
+			"timestamp": "2024-11-15T18:46:15.641Z"
+		},
+		{
+			"id": 1049,
+			"userId": "104464697775882240",
+			"model": "Completion",
+			"recordId": "60741",
+			"name": "SoulOrg Endurance||Framzo, nameless",
+			"action": "create",
+			"timestamp": "2024-11-15T20:06:48.644Z"
+		},
+		{
+			"id": 1050,
+			"userId": "261983800429510658",
+			"model": "Completion",
+			"recordId": "60742",
+			"name": "SoulOrg Endurance||nameless, Framzo",
+			"action": "create",
+			"timestamp": "2024-11-15T22:30:26.148Z"
+		},
+		{
+			"id": 1051,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60743",
+			"name": "Baka, Baka, Baka||Faith, Sierra",
+			"action": "create",
+			"timestamp": "2024-11-16T00:49:58.119Z"
+		},
+		{
+			"id": 1052,
+			"userId": "292774728014364686",
+			"model": "Mission",
+			"recordId": "10794",
+			"name": "Achievement Hunter",
+			"action": "create",
+			"timestamp": "2024-11-16T15:58:25.152Z"
+		},
+		{
+			"id": 1053,
+			"userId": "628939105480474636",
+			"model": "Completion",
+			"recordId": "60744",
+			"name": "ÜberKlax Endurance||TheBigBadBull, _Play_",
+			"action": "create",
+			"timestamp": "2024-11-16T16:48:42.685Z"
+		},
+		{
+			"id": 1054,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10792",
+			"name": "7-Segmented Madness",
+			"action": "update",
+			"timestamp": "2024-11-16T18:32:40.676Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 5460,
+								"pools": [
+									{ "count": 1, "modules": ["accumulation"] },
+									{ "count": 1, "modules": ["lgndHyperactiveNumbers"] },
+									{ "count": 1, "modules": ["modulo"] },
+									{ "count": 1, "modules": ["GSNumberCruncher"] },
+									{ "count": 1, "modules": ["pwGenerator"] },
+									{ "count": 1, "modules": ["sevenWires"] },
+									{ "count": 1, "modules": ["simonsStar"] }
+								],
+								"modules": 7,
+								"strikes": 4,
+								"widgets": 7
+							},
+							"where": { "id": 14808 }
+						},
+						{
+							"data": {
+								"time": 5460,
+								"pools": [
+									{ "count": 1, "modules": ["CosmicModule"] },
+									{ "count": 1, "modules": ["digitalDials"] },
+									{ "count": 1, "modules": ["DoubleOhModule"] },
+									{ "count": 1, "modules": ["modulusManipulation"] },
+									{ "count": 1, "modules": ["rgbMaze"] },
+									{ "count": 1, "modules": ["simonsStages"] },
+									{ "count": 1, "modules": ["subscribeToPewdiepie"] }
+								],
+								"modules": 7,
+								"strikes": 4,
+								"widgets": 7
+							},
+							"where": { "id": 14809 }
+						},
+						{
+							"data": {
+								"time": 5460,
+								"pools": [
+									{ "count": 1, "modules": ["burglarAlarm"] },
+									{ "count": 1, "modules": ["combinationLock"] },
+									{ "count": 1, "modules": ["cooking"] },
+									{ "count": 1, "modules": ["TheGamepadModule"] },
+									{ "count": 1, "modules": ["lunchtime"] },
+									{ "count": 1, "modules": ["Mastermind Simple"] },
+									{ "count": 1, "modules": ["timezone"] }
+								],
+								"modules": 7,
+								"strikes": 4,
+								"widgets": 7
+							},
+							"where": { "id": 14810 }
+						},
+						{
+							"data": {
+								"time": 5460,
+								"pools": [
+									{ "count": 1, "modules": ["0"] },
+									{ "count": 1, "modules": ["arithmelogic"] },
+									{ "count": 1, "modules": ["bases"] },
+									{ "count": 1, "modules": ["digitString"] },
+									{ "count": 1, "modules": ["equations"] },
+									{ "count": 1, "modules": ["ForgetAnyColor"] },
+									{ "count": 1, "modules": ["qFunctions"] }
+								],
+								"modules": 7,
+								"strikes": 4,
+								"widgets": 7
+							},
+							"where": { "id": 14811 }
+						},
+						{
+							"data": {
+								"time": 5460,
+								"pools": [
+									{ "count": 1, "modules": ["threeNPlusOne"] },
+									{ "count": 1, "modules": ["cube"] },
+									{ "count": 1, "modules": ["FlagsModule"] },
+									{ "count": 1, "modules": ["mazematics"] },
+									{ "count": 1, "modules": ["PolyhedralMazeModule"] },
+									{ "count": 1, "modules": ["SynchronizationModule"] },
+									{ "count": 1, "modules": ["timeKeeper"] }
+								],
+								"modules": 7,
+								"strikes": 4,
+								"widgets": 7
+							},
+							"where": { "id": 14812 }
+						},
+						{
+							"data": {
+								"time": 5460,
+								"pools": [
+									{ "count": 1, "modules": ["burgerAlarm"] },
+									{ "count": 1, "modules": ["colorfulDials"] },
+									{ "count": 1, "modules": ["cruelModulo"] },
+									{ "count": 1, "modules": ["CursedDoubleOhModule"] },
+									{ "count": 1, "modules": ["faultyrgbMaze"] },
+									{ "count": 1, "modules": ["Mastermind Cruel"] },
+									{ "count": 1, "modules": ["SecurityCouncil"] }
+								],
+								"modules": 7,
+								"strikes": 4,
+								"widgets": 7
+							},
+							"where": { "id": 14813 }
+						},
+						{
+							"data": {
+								"time": 5460,
+								"pools": [
+									{ "count": 1, "modules": ["7"] },
+									{ "count": 1, "modules": ["ksmAmazeingButtons"] },
+									{ "count": 1, "modules": ["boolMazeCruel"] },
+									{ "count": 1, "modules": ["faulty7SegmentDisplays"] },
+									{ "count": 1, "modules": ["hereditaryBaseNotationModule"] },
+									{ "count": 1, "modules": ["NotTimerModule"] },
+									{ "count": 1, "modules": ["SpellingBuzzed"] }
+								],
+								"modules": 7,
+								"strikes": 4,
+								"widgets": 7
+							},
+							"where": { "id": 14814 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 1055,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10792",
+			"name": "7-Segmented Madness",
+			"action": "update",
+			"timestamp": "2024-11-16T18:32:40.701Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=fd13bdd5a4f570c0a50301cc16aeca383d65baf2" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=11787f62872c172f52f713a4f126f4f5dc43524f" }
+		},
+		{
+			"id": 1056,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10785",
+			"name": "#things-blan-does-not-know",
+			"action": "update",
+			"timestamp": "2024-11-16T18:35:28.445Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1057,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10788",
+			"name": "Baking Soda",
+			"action": "update",
+			"timestamp": "2024-11-16T18:35:30.737Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1058,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10789",
+			"name": "Vocal Catastrophe",
+			"action": "update",
+			"timestamp": "2024-11-16T18:35:31.663Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1059,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10790",
+			"name": "Every Copy of KTaNE Is Personalised",
+			"action": "update",
+			"timestamp": "2024-11-16T18:35:32.289Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1060,
+			"userId": "292774728014364686",
+			"model": "Mission",
+			"recordId": "10795",
+			"name": "Five Stars v1",
+			"action": "create",
+			"timestamp": "2024-11-16T18:54:14.044Z"
+		},
+		{
+			"id": 1061,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60745",
+			"name": "Baking Soda||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-11-16T21:41:27.895Z"
+		},
+		{
+			"id": 1062,
+			"userId": "455035517872898050",
+			"model": "Completion",
+			"recordId": "60746",
+			"name": "Pink||_Play_",
+			"action": "create",
+			"timestamp": "2024-11-16T21:59:48.598Z"
+		},
+		{
+			"id": 1063,
+			"userId": "455035517872898050",
+			"model": "Completion",
+			"recordId": "60747",
+			"name": "Nothing To Spare: Quickly Now!||_Play_",
+			"action": "create",
+			"timestamp": "2024-11-16T22:41:07.701Z"
+		},
+		{
+			"id": 1064,
+			"userId": "243193229661569024",
+			"model": "Completion",
+			"recordId": "60748",
+			"name": "All Five Bomb||Dicey",
+			"action": "create",
+			"timestamp": "2024-11-16T22:46:10.521Z"
+		},
+		{
+			"id": 1065,
+			"userId": "485774478282981376",
+			"model": "Completion",
+			"recordId": "60749",
+			"name": "NoT!: Niigo||weird, Sierra, YourokahnTMF",
+			"action": "create",
+			"timestamp": "2024-11-17T05:14:52.796Z"
+		},
+		{
+			"id": 1066,
+			"userId": "980292547823931475",
+			"model": "Completion",
+			"recordId": "60750",
+			"name": "Redundancy Front Prime||TylerY2992, Men in Black",
+			"action": "create",
+			"timestamp": "2024-11-17T06:28:47.539Z"
+		},
+		{
+			"id": 1067,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60741",
+			"name": "SoulOrg Endurance||Framzo, nameless",
+			"action": "update",
+			"timestamp": "2024-11-17T09:33:42.428Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1068,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60736",
+			"name": "Nightmare Mode: Savor the Moment||Benjamin, Bianca, Burniel",
+			"action": "update",
+			"timestamp": "2024-11-17T09:33:58.711Z",
+			"before": {
+				"proofs": [
+					"https://www.youtube.com/watch?v=cfKA0waAytw",
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=1a404658164c17350f16dd88a9d7fc3ec3d43f18;bomb=I99VA3"
+				]
+			},
+			"after": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=1a404658164c17350f16dd88a9d7fc3ec3d43f18;bomb=I99VA3",
+					"https://www.youtube.com/watch?v=cfKA0waAytw"
+				]
+			}
+		},
+		{
+			"id": 1069,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60740",
+			"name": "Nightmare Mode: Savor the Moment||Benjamin, Bianca, Burniel",
+			"action": "delete",
+			"timestamp": "2024-11-17T09:33:58.721Z",
+			"before": {
+				"id": 60740,
+				"old": false,
+				"solo": false,
+				"team": ["Benjamin", "Bianca", "Burniel"],
+				"time": 68.18,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=1a404658164c17350f16dd88a9d7fc3ec3d43f18;bomb=I99VA3",
+					"https://www.youtube.com/watch?v=cfKA0waAytw"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-15T18:45:26.836Z",
+				"missionId": 10775,
+				"uploadedBy": "337934133751840769"
+			}
+		},
+		{
+			"id": 1070,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60742",
+			"name": "SoulOrg Endurance||nameless, Framzo",
+			"action": "update",
+			"timestamp": "2024-11-17T09:35:29.769Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1071,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60743",
+			"name": "Baka, Baka, Baka||Faith, Sierra",
+			"action": "update",
+			"timestamp": "2024-11-17T09:36:02.769Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1072,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60744",
+			"name": "ÜberKlax Endurance||TheBigBadBull, _Play_",
+			"action": "update",
+			"timestamp": "2024-11-17T09:36:53.365Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1073,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60745",
+			"name": "Baking Soda||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-11-17T09:37:21.723Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 1074,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60746",
+			"name": "Pink||_Play_",
+			"action": "update",
+			"timestamp": "2024-11-17T09:38:25.703Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1075,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60751",
+			"name": "Uber Forget Me Not||Termet",
+			"action": "create",
+			"timestamp": "2024-11-17T13:03:23.106Z"
+		},
+		{
+			"id": 1076,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60752",
+			"name": "The Peanor||Sierra",
+			"action": "create",
+			"timestamp": "2024-11-17T20:07:55.801Z"
+		},
+		{
+			"id": 1077,
+			"userId": "488806494872272898",
+			"model": "Mission",
+			"recordId": "10796",
+			"name": "Termet's 47",
+			"action": "create",
+			"timestamp": "2024-11-17T20:48:34.876Z"
+		},
+		{
+			"id": 1078,
+			"userId": "198971491398713345",
+			"model": "Mission",
+			"recordId": "10797",
+			"name": "Ruby's Ultimate 47",
+			"action": "create",
+			"timestamp": "2024-11-18T00:06:06.339Z"
+		},
+		{
+			"id": 1079,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60753",
+			"name": "Silence Madness||AzaFTW, Sierra",
+			"action": "create",
+			"timestamp": "2024-11-18T00:20:17.185Z"
+		},
+		{
+			"id": 1080,
+			"userId": "537999725861928971",
+			"model": "Completion",
+			"recordId": "60754",
+			"name": "Asmir's 47||QuantumCat27, mythicalrocket",
+			"action": "create",
+			"timestamp": "2024-11-18T00:40:13.504Z"
+		},
+		{
+			"id": 1081,
+			"userId": "589237691691040798",
+			"model": "Completion",
+			"recordId": "60755",
+			"name": "ÜberKlax Endurance||Masked Mystery, StalledStorm775, LitAiden",
+			"action": "create",
+			"timestamp": "2024-11-18T01:48:58.473Z"
+		},
+		{
+			"id": 1082,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60756",
+			"name": "Nothing To Spare: Another Quick Bomb||denial140, Lyph",
+			"action": "create",
+			"timestamp": "2024-11-18T04:03:37.363Z"
+		},
+		{
+			"id": 1083,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60757",
+			"name": "Nothing To Spare: Another Quick Bomb||denial140",
+			"action": "create",
+			"timestamp": "2024-11-18T08:04:24.660Z"
+		},
+		{
+			"id": 1084,
+			"userId": "485774478282981376",
+			"model": "Completion",
+			"recordId": "60758",
+			"name": "Nexus||weird",
+			"action": "create",
+			"timestamp": "2024-11-18T09:44:24.046Z"
+		},
+		{
+			"id": 1085,
+			"userId": "348089371397849088",
+			"model": "Mission",
+			"recordId": "10798",
+			"name": "Witek's Mental Asylum",
+			"action": "create",
+			"timestamp": "2024-11-18T12:43:01.367Z"
+		},
+		{
+			"id": 1086,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60759",
+			"name": "CentuRYAN||Termet",
+			"action": "create",
+			"timestamp": "2024-11-18T16:01:40.616Z"
+		},
+		{
+			"id": 1087,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60760",
+			"name": "Exit This Earth's Atomosphere||Sierra",
+			"action": "create",
+			"timestamp": "2024-11-18T17:27:06.596Z"
+		},
+		{
+			"id": 1088,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10797",
+			"name": "Ruby's Ultimate 47",
+			"action": "update",
+			"timestamp": "2024-11-18T18:25:33.918Z",
+			"before": { "authors": ["Ruby"] },
+			"after": { "authors": ["RubyBfb"] }
+		},
+		{
+			"id": 1089,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10783",
+			"name": "Step By Step",
+			"action": "update",
+			"timestamp": "2024-11-18T18:33:23.554Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1090,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10799",
+			"name": "[[UPDATE]] Step By Step",
+			"action": "create",
+			"timestamp": "2024-11-18T18:34:03.076Z"
+		},
+		{
+			"id": 1091,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10783",
+			"name": "Step By Step",
+			"action": "update",
+			"timestamp": "2024-11-18T18:34:07.810Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=89b3dbacb25b483ca354a9df4b260142abdc3c55" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 4500,
+							"pools": [
+								{ "count": 1, "modules": ["TwoPersuasiveButtons"] },
+								{ "count": 1, "modules": ["navinums"] },
+								{ "count": 1, "modules": ["buttonSequencesModule"] },
+								{ "count": 1, "modules": ["logicalButtonsModule"] },
+								{ "count": 1, "modules": ["R4YRecoloredSwitches"] },
+								{ "count": 1, "modules": ["colouredArrowsModule"] },
+								{ "count": 1, "modules": ["orangeArrowsModule"] },
+								{ "count": 1, "modules": ["greenArrowsModule"] },
+								{ "count": 1, "modules": ["NextInLine"] },
+								{ "count": 1, "modules": ["NotWireSequence"] },
+								{ "count": 1, "modules": ["booleanWires"] },
+								{ "count": 1, "modules": ["symbolicCoordinates"] },
+								{ "count": 1, "modules": ["lgndZoni"] },
+								{ "count": 1, "modules": ["cube"] },
+								{ "count": 1, "modules": ["hunting"] },
+								{ "count": 1, "modules": ["triangle"] },
+								{ "count": 1, "modules": ["screw"] },
+								{ "count": 1, "modules": ["simplysimon"] },
+								{ "count": 1, "modules": ["SimonScreamsModule"] },
+								{ "count": 1, "modules": ["simonSubdivides"] },
+								{ "count": 1, "modules": ["LEDEnc"] },
+								{ "count": 1, "modules": ["memoryWires"] },
+								{ "count": 1, "modules": ["poetry"] },
+								{ "count": 1, "modules": ["SeaShells"] },
+								{ "count": 1, "modules": ["Detonato"] },
+								{ "count": 1, "modules": ["ThirdBase"] },
+								{ "count": 1, "modules": ["challengeAndContact"] },
+								{ "count": 1, "modules": ["simonSimons"] },
+								{ "count": 1, "modules": ["simonSaidModule"] },
+								{ "count": 1, "modules": ["SimonV2"] },
+								{ "count": 1, "modules": ["simonsOnFirst"] },
+								{ "count": 1, "modules": ["simonsStar"] },
+								{ "count": 1, "modules": ["tashaSqueals"] },
+								{ "count": 1, "modules": ["symbolicTasha"] },
+								{ "count": 1, "modules": ["SimonSpeaksModule"] },
+								{ "count": 1, "modules": ["SimonSpinsModule"] },
+								{ "count": 1, "modules": ["horribleMemory"] },
+								{ "count": 1, "modules": ["MadMemory"] },
+								{ "count": 1, "modules": ["labyrinth"] },
+								{ "count": 1, "modules": ["rgbMaze"] },
+								{ "count": 1, "modules": ["3dTunnels"] },
+								{ "count": 1, "modules": ["BlackHoleModule"] },
+								{ "count": 1, "modules": ["MemoryV2"] },
+								{ "count": 1, "modules": ["accumulation"] },
+								{ "count": 1, "modules": ["algebra"] },
+								{ "count": 1, "modules": ["iceCreamModule"] },
+								{ "count": 1, "modules": ["SillySlots"] }
+							],
+							"modules": 47,
+							"strikes": 4,
+							"widgets": 5
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=0e0b2949f27917a76511d1ea2720001ad5bef75c"
+			}
+		},
+		{
+			"id": 1092,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10799",
+			"name": "[[UPDATE]] Step By Step",
+			"action": "delete",
+			"timestamp": "2024-11-18T18:34:07.830Z",
+			"before": {
+				"id": 10799,
+				"name": "[[UPDATE]] Step By Step",
+				"notes": null,
+				"authors": ["Sideral9999"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=0e0b2949f27917a76511d1ea2720001ad5bef75c",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_toc_HexiAdvancedBaseModules_0_SectionTitle_3: \"Complex Contraptions\"",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-11-18T18:33:33.890Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "486602438103531520",
+				"designedForTP": false,
+				"missionPackId": 588
+			}
+		},
+		{
+			"id": 1093,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60761",
+			"name": "17 Again||Termet",
+			"action": "create",
+			"timestamp": "2024-11-18T19:19:00.573Z"
+		},
+		{
+			"id": 1094,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10800",
+			"name": "[[UPDATE]] Every Copy of KTaNE Is Personalised",
+			"action": "create",
+			"timestamp": "2024-11-18T19:30:45.204Z"
+		},
+		{
+			"id": 1095,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60747",
+			"name": "Nothing To Spare: Quickly Now!||_Play_",
+			"action": "update",
+			"timestamp": "2024-11-18T22:36:44.857Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1096,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60748",
+			"name": "All Five Bomb||Dicey",
+			"action": "update",
+			"timestamp": "2024-11-18T22:37:07.593Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1097,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60749",
+			"name": "NoT!: Niigo||weird, Sierra, YourokahnTMF",
+			"action": "update",
+			"timestamp": "2024-11-18T22:38:36.139Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 1098,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60750",
+			"name": "Redundancy Front Prime||TylerY2992, Men in Black",
+			"action": "update",
+			"timestamp": "2024-11-18T22:38:51.670Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1099,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60751",
+			"name": "Uber Forget Me Not||Termet",
+			"action": "update",
+			"timestamp": "2024-11-18T22:39:30.621Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1100,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60752",
+			"name": "The Peanor||Sierra",
+			"action": "update",
+			"timestamp": "2024-11-18T22:40:45.076Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1101,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60753",
+			"name": "Silence Madness||AzaFTW, Sierra",
+			"action": "update",
+			"timestamp": "2024-11-18T22:41:36.708Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1102,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60754",
+			"name": "Asmir's 47||QuantumCat27, mythicalrocket",
+			"action": "update",
+			"timestamp": "2024-11-18T22:43:05.733Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1103,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60755",
+			"name": "ÜberKlax Endurance||Masked Mystery, StalledStorm775, LitAiden",
+			"action": "update",
+			"timestamp": "2024-11-18T22:43:25.610Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1104,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60762",
+			"name": "The Kármán Line||Sierra",
+			"action": "create",
+			"timestamp": "2024-11-18T23:35:04.961Z"
+		},
+		{
+			"id": 1105,
+			"userId": "678178906871955473",
+			"model": "Completion",
+			"recordId": "60763",
+			"name": "ÜberKlax Endurance||StalledStorm775, Masked Mystery",
+			"action": "create",
+			"timestamp": "2024-11-18T23:54:59.653Z"
+		},
+		{
+			"id": 1106,
+			"userId": "980292547823931475",
+			"model": "Completion",
+			"recordId": "60764",
+			"name": "Olievenhoutbosch||TylerY2992, Men in Black, Mr. Punchy",
+			"action": "create",
+			"timestamp": "2024-11-19T03:58:31.946Z"
+		},
+		{
+			"id": 1107,
+			"userId": "294221057311899649",
+			"model": "Completion",
+			"recordId": "60765",
+			"name": "Doringkloof||GreenPower, Lucco, Guck, LeJusDOrange",
+			"action": "create",
+			"timestamp": "2024-11-19T04:04:52.552Z"
+		},
+		{
+			"id": 1108,
+			"userId": "294221057311899649",
+			"model": "Completion",
+			"recordId": "60766",
+			"name": "Eldoraigne||GreenPower, Lucco, Guck, LeJusDOrange",
+			"action": "create",
+			"timestamp": "2024-11-19T04:05:21.478Z"
+		},
+		{
+			"id": 1109,
+			"userId": "434345780375977994",
+			"model": "Completion",
+			"recordId": "60767",
+			"name": "SoulOrg Endurance (Cruel)||Masked Mystery, Ayeka",
+			"action": "create",
+			"timestamp": "2024-11-19T05:14:39.151Z"
+		},
+		{
+			"id": 1110,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60768",
+			"name": "Nightmare Mode: Savor the Moment||denial140",
+			"action": "create",
+			"timestamp": "2024-11-19T11:52:21.575Z"
+		},
+		{
+			"id": 1111,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60769",
+			"name": "An Idol||Termet",
+			"action": "create",
+			"timestamp": "2024-11-19T15:24:02.545Z"
+		},
+		{
+			"id": 1112,
+			"userId": "678178906871955473",
+			"model": "Completion",
+			"recordId": "60770",
+			"name": "SoulOrg Endurance||StalledStorm775",
+			"action": "create",
+			"timestamp": "2024-11-19T22:08:42.210Z"
+		},
+		{
+			"id": 1113,
+			"userId": "678178906871955473",
+			"model": "Completion",
+			"recordId": "60771",
+			"name": "Easy Challenge||StalledStorm775",
+			"action": "create",
+			"timestamp": "2024-11-20T00:12:34.586Z"
+		},
+		{
+			"id": 1114,
+			"userId": "689219553531658292",
+			"model": "Completion",
+			"recordId": "60772",
+			"name": "Baking Soda||Faith, Sierra",
+			"action": "create",
+			"timestamp": "2024-11-20T02:16:18.036Z"
+		},
+		{
+			"id": 1115,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60756",
+			"name": "Nothing To Spare: Another Quick Bomb||denial140, Lyph",
+			"action": "update",
+			"timestamp": "2024-11-20T12:58:02.710Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1116,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "59142",
+			"name": "Nothing To Spare: Another Quick Bomb||denial140",
+			"action": "update",
+			"timestamp": "2024-11-20T12:59:24.517Z",
+			"before": {
+				"time": 551.31,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=aae16a263c1a0da647597974dcaea2ee04fb7652;bomb=MH2EN1",
+					"https://youtu.be/mbhSXk_rmUU"
+				]
+			},
+			"after": {
+				"time": 677.75,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=16c2ae4dc57d089ed82e2778a50d8764664385e8;bomb=PS9ES0",
+					"https://youtu.be/TGQ1X4EXTJg"
+				]
+			}
+		},
+		{
+			"id": 1117,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60757",
+			"name": "Nothing To Spare: Another Quick Bomb||denial140",
+			"action": "delete",
+			"timestamp": "2024-11-20T12:59:24.539Z",
+			"before": {
+				"id": 60757,
+				"old": false,
+				"solo": false,
+				"team": ["denial140"],
+				"time": 677.75,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=16c2ae4dc57d089ed82e2778a50d8764664385e8;bomb=PS9ES0",
+					"https://youtu.be/TGQ1X4EXTJg"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-18T07:53:35.108Z",
+				"missionId": 9542,
+				"uploadedBy": "118831126239248397"
+			}
+		},
+		{
+			"id": 1118,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60758",
+			"name": "Nexus||weird",
+			"action": "update",
+			"timestamp": "2024-11-20T12:59:54.485Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1119,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60759",
+			"name": "CentuRYAN||Termet",
+			"action": "update",
+			"timestamp": "2024-11-20T13:01:16.314Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1120,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60760",
+			"name": "Exit This Earth's Atomosphere||Sierra",
+			"action": "update",
+			"timestamp": "2024-11-20T13:02:10.732Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1121,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60761",
+			"name": "17 Again||Termet",
+			"action": "update",
+			"timestamp": "2024-11-20T13:02:59.784Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1122,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60762",
+			"name": "The Kármán Line||Sierra",
+			"action": "update",
+			"timestamp": "2024-11-20T13:03:28.913Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1123,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60763",
+			"name": "ÜberKlax Endurance||StalledStorm775, Masked Mystery",
+			"action": "update",
+			"timestamp": "2024-11-20T13:04:08.407Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1124,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60764",
+			"name": "Olievenhoutbosch||TylerY2992, Men in Black, Mr. Punchy",
+			"action": "update",
+			"timestamp": "2024-11-20T13:04:47.710Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1125,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60765",
+			"name": "Doringkloof||GreenPower, Lucco, Guck, LeJusDOrange",
+			"action": "update",
+			"timestamp": "2024-11-20T13:06:11.692Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1126,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60766",
+			"name": "Eldoraigne||GreenPower, Lucco, Guck, LeJusDOrange",
+			"action": "update",
+			"timestamp": "2024-11-20T13:07:06.811Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1127,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60767",
+			"name": "SoulOrg Endurance (Cruel)||Masked Mystery, Ayeka",
+			"action": "update",
+			"timestamp": "2024-11-20T13:07:50.769Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1128,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10790",
+			"name": "Every Copy of KTaNE Is Personalised",
+			"action": "update",
+			"timestamp": "2024-11-20T13:08:37.436Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=537919fa07a4cd7a0b6a66583680d9f99a050c8d" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 7800,
+							"pools": [
+								{ "count": 1, "modules": ["codenames"] },
+								{ "count": 1, "modules": ["Tangrams"] },
+								{ "count": 1, "modules": ["Microcontroller"] },
+								{ "count": 1, "modules": ["TennisModule"] },
+								{ "count": 1, "modules": ["numberNimbleness"] },
+								{ "count": 1, "modules": ["dumbWaiters"] },
+								{ "count": 1, "modules": ["Wavetapping"] },
+								{ "count": 1, "modules": ["brushStrokes"] },
+								{ "count": 1, "modules": ["OddOneOutModule"] },
+								{ "count": 1, "modules": ["FaultySink"] },
+								{ "count": 1, "modules": ["jumbleCycle"] },
+								{ "count": 1, "modules": ["modkit"] },
+								{ "count": 1, "modules": ["sevenChooseFour"] },
+								{ "count": 1, "modules": ["ultimateCipher"] },
+								{ "count": 1, "modules": ["cipherMachine"] },
+								{ "count": 1, "modules": ["punctuationMarks"] },
+								{ "count": 1, "modules": ["sorting"] },
+								{ "count": 1, "modules": ["masherTheBottun"] },
+								{ "count": 1, "modules": ["theCruelDuck"] },
+								{ "count": 1, "modules": ["deckOfManyThings"] },
+								{ "count": 1, "modules": ["cruelCandyLand"] },
+								{ "count": 1, "modules": ["simonsUltimateShowdownModule"] },
+								{ "count": 1, "modules": ["ForgetsUltimateShowdownModule"] },
+								{ "count": 1, "modules": ["VarietyModule"] },
+								{ "count": 1, "modules": ["KritModuleSprint"] },
+								{ "count": 1, "modules": ["ReformedRoleReversal"] },
+								{ "count": 1, "modules": ["faultyChineseCounting"] },
+								{ "count": 1, "modules": ["labeledPrioritiesPlus"] },
+								{ "count": 1, "modules": ["Linq"] },
+								{ "count": 1, "modules": ["CrittersModule"] },
+								{ "count": 1, "modules": ["notIdentification"] },
+								{ "count": 1, "modules": ["presidentialElections"] },
+								{ "count": 1, "modules": ["videoPoker"] },
+								{ "count": 1, "modules": ["lousyChess"] },
+								{ "count": 1, "modules": ["knotWires"] },
+								{ "count": 1, "modules": ["ObscurdleModule"] },
+								{ "count": 1, "modules": ["neptune"] },
+								{ "count": 1, "modules": ["alphabeticalRuling"] },
+								{ "count": 1, "modules": ["airStrikes"] },
+								{ "count": 1, "modules": ["cannymaze"] },
+								{ "count": 1, "modules": ["GSNumberCruncher"] },
+								{ "count": 1, "modules": ["metalmaths"] },
+								{ "count": 1, "modules": ["encryptionBingo"] },
+								{ "count": 1, "modules": ["understand"] },
+								{ "count": 1, "modules": ["bakery"] },
+								{ "count": 1, "modules": ["algorithmia"] },
+								{ "count": 1, "modules": ["unfairsRevengeCruel"] }
+							],
+							"modules": 47,
+							"strikes": 6,
+							"widgets": 5
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=32ea77336c4177ef2bd8b5d1754b6cadd4be46a1"
+			}
+		},
+		{
+			"id": 1129,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10800",
+			"name": "[[UPDATE]] Every Copy of KTaNE Is Personalised",
+			"action": "delete",
+			"timestamp": "2024-11-20T13:08:37.452Z",
+			"before": {
+				"id": 10800,
+				"name": "[[UPDATE]] Every Copy of KTaNE Is Personalised",
+				"notes": null,
+				"authors": ["Axodeau"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=32ea77336c4177ef2bd8b5d1754b6cadd4be46a1",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_AxoRandoMission_Every Copy of KTaNE Is Personalised",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-11-18T19:30:24.828Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "832703757615497298",
+				"designedForTP": false,
+				"missionPackId": 404
+			}
+		},
+		{
+			"id": 1130,
+			"userId": "678178906871955473",
+			"model": "Completion",
+			"recordId": "60773",
+			"name": "SoulOrg Endurance||StalledStorm775, Masked Mystery",
+			"action": "create",
+			"timestamp": "2024-11-21T00:37:02.025Z"
+		},
+		{
+			"id": 1131,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60768",
+			"name": "Nightmare Mode: Savor the Moment||denial140",
+			"action": "update",
+			"timestamp": "2024-11-21T08:16:13.654Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1132,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60769",
+			"name": "An Idol||Termet",
+			"action": "update",
+			"timestamp": "2024-11-21T08:16:47.645Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1133,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60770",
+			"name": "SoulOrg Endurance||StalledStorm775",
+			"action": "update",
+			"timestamp": "2024-11-21T08:17:05.727Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1134,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60771",
+			"name": "Easy Challenge||StalledStorm775",
+			"action": "update",
+			"timestamp": "2024-11-21T08:17:38.392Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1135,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60772",
+			"name": "Baking Soda||Faith, Sierra",
+			"action": "update",
+			"timestamp": "2024-11-21T08:19:27.457Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1136,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60773",
+			"name": "SoulOrg Endurance||StalledStorm775, Masked Mystery",
+			"action": "update",
+			"timestamp": "2024-11-21T08:19:54.876Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1137,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60774",
+			"name": "Baking Soda||Kugel",
+			"action": "create",
+			"timestamp": "2024-11-21T10:24:21.749Z"
+		},
+		{
+			"id": 1138,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60775",
+			"name": "Pocket Change||Termet",
+			"action": "create",
+			"timestamp": "2024-11-21T18:07:56.671Z"
+		},
+		{
+			"id": 1139,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60776",
+			"name": "Great Berate's Endurance Challenge||denial140",
+			"action": "create",
+			"timestamp": "2024-11-21T19:31:50.435Z"
+		},
+		{
+			"id": 1140,
+			"userId": "678178906871955473",
+			"model": "Completion",
+			"recordId": "60777",
+			"name": "SoulOrg Endurance||Masked Mystery, StalledStorm775",
+			"action": "create",
+			"timestamp": "2024-11-21T23:20:13.369Z"
+		},
+		{
+			"id": 1141,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60778",
+			"name": "Organisation Rush||AzaFTW, Termet",
+			"action": "create",
+			"timestamp": "2024-11-22T00:53:59.312Z"
+		},
+		{
+			"id": 1142,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60779",
+			"name": "Series of Similarities||Kugel",
+			"action": "create",
+			"timestamp": "2024-11-22T01:43:39.630Z"
+		},
+		{
+			"id": 1143,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60774",
+			"name": "Baking Soda||Kugel",
+			"action": "update",
+			"timestamp": "2024-11-22T08:09:43.856Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1144,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60775",
+			"name": "Pocket Change||Termet",
+			"action": "update",
+			"timestamp": "2024-11-22T08:10:13.219Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1145,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60776",
+			"name": "Great Berate's Endurance Challenge||denial140",
+			"action": "update",
+			"timestamp": "2024-11-22T08:11:20.097Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1146,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60777",
+			"name": "SoulOrg Endurance||Masked Mystery, StalledStorm775",
+			"action": "update",
+			"timestamp": "2024-11-22T08:12:14.786Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1147,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60778",
+			"name": "Organisation Rush||AzaFTW, Termet",
+			"action": "update",
+			"timestamp": "2024-11-22T08:13:31.426Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1148,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60779",
+			"name": "Series of Similarities||Kugel",
+			"action": "update",
+			"timestamp": "2024-11-22T08:14:03.570Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1149,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60780",
+			"name": "NoT!: Niigo||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-22T16:08:37.490Z"
+		},
+		{
+			"id": 1150,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60780",
+			"name": "NoT!: Niigo||Twitch Plays",
+			"action": "delete",
+			"timestamp": "2024-11-22T16:08:43.966Z",
+			"before": {
+				"id": 60780,
+				"old": false,
+				"solo": false,
+				"team": ["Twitch Plays"],
+				"time": 1794.98,
+				"first": false,
+				"notes": null,
+				"proofs": ["https://ktane.timwi.de/lfa#file=51db0fb0721e914f11da5d9a7b44b7b33160c5f0"],
+				"verified": false,
+				"dateAdded": "2024-11-22T16:08:24.947Z",
+				"missionId": 10763,
+				"uploadedBy": "213189526837919745"
+			}
+		},
+		{
+			"id": 1151,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60781",
+			"name": "In2sity||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-22T16:09:02.646Z"
+		},
+		{
+			"id": 1152,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60782",
+			"name": "The Easifier||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-22T16:09:41.222Z"
+		},
+		{
+			"id": 1153,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60783",
+			"name": "Troisturion||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-22T16:09:48.748Z"
+		},
+		{
+			"id": 1154,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60784",
+			"name": "Everyone's Least Favorite Boss||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-22T16:09:55.586Z"
+		},
+		{
+			"id": 1155,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60785",
+			"name": "Arleen's Favorite 47||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-22T16:10:06.520Z"
+		},
+		{
+			"id": 1156,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60781",
+			"name": "In2sity||Twitch Plays",
+			"action": "delete",
+			"timestamp": "2024-11-22T16:10:10.850Z",
+			"before": {
+				"id": 60781,
+				"old": false,
+				"solo": false,
+				"team": ["Twitch Plays"],
+				"time": 2104.79,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=f7aadc99c3b885ada4112999d835dfaee5f6745a;bomb=592QB4"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-22T16:08:58.549Z",
+				"missionId": 10675,
+				"uploadedBy": "213189526837919745"
+			}
+		},
+		{
+			"id": 1157,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10719",
+			"name": "The Easifier",
+			"action": "update",
+			"timestamp": "2024-11-22T16:10:11.840Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1158,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60782",
+			"name": "The Easifier||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-22T16:10:11.850Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1159,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9928",
+			"name": "Troisturion",
+			"action": "update",
+			"timestamp": "2024-11-22T16:10:12.656Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1160,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60783",
+			"name": "Troisturion||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-22T16:10:12.666Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1161,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10773",
+			"name": "Everyone's Least Favorite Boss",
+			"action": "update",
+			"timestamp": "2024-11-22T16:10:13.472Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1162,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60784",
+			"name": "Everyone's Least Favorite Boss||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-22T16:10:13.480Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1163,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10176",
+			"name": "Arleen's Favorite 47",
+			"action": "update",
+			"timestamp": "2024-11-22T16:10:14.349Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1164,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60785",
+			"name": "Arleen's Favorite 47||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-22T16:10:14.357Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1165,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10801",
+			"name": "InDiscrete Topology",
+			"action": "create",
+			"timestamp": "2024-11-22T19:04:55.940Z"
+		},
+		{
+			"id": 1166,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60786",
+			"name": "Praetorian New Ones||Termet",
+			"action": "create",
+			"timestamp": "2024-11-22T19:33:15.464Z"
+		},
+		{
+			"id": 1167,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60786",
+			"name": "Praetorian New Ones||Termet",
+			"action": "update",
+			"timestamp": "2024-11-22T20:05:04.595Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1168,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60787",
+			"name": "Rainbow Punch||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-22T20:12:46.867Z"
+		},
+		{
+			"id": 1169,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10022",
+			"name": "Rainbow Punch",
+			"action": "update",
+			"timestamp": "2024-11-22T20:12:49.362Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1170,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60787",
+			"name": "Rainbow Punch||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-22T20:12:49.371Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1171,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10801",
+			"name": "InDiscrete Topology",
+			"action": "update",
+			"timestamp": "2024-11-22T22:35:45.128Z",
+			"before": { "notes": null },
+			"after": { "notes": "The Octadecayotton is configured to 3 dimensions." }
+		},
+		{
+			"id": 1172,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60788",
+			"name": "Great Berate's Endurance Challenge||Sierra, Termet",
+			"action": "create",
+			"timestamp": "2024-11-22T23:11:49.732Z"
+		},
+		{
+			"id": 1173,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60789",
+			"name": "Rules That Doesn't Exist||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-23T00:37:03.463Z"
+		},
+		{
+			"id": 1174,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9608",
+			"name": "Rules That Doesn't Exist",
+			"action": "update",
+			"timestamp": "2024-11-23T00:37:05.812Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1175,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60789",
+			"name": "Rules That Doesn't Exist||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-23T00:37:05.822Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1176,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10792",
+			"name": "7-Segmented Madness",
+			"action": "update",
+			"timestamp": "2024-11-23T09:17:40.208Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1177,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10793",
+			"name": "Pipe Dream",
+			"action": "update",
+			"timestamp": "2024-11-23T09:17:41.040Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1178,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10794",
+			"name": "Achievement Hunter",
+			"action": "update",
+			"timestamp": "2024-11-23T09:17:41.650Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1179,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10795",
+			"name": "Five Stars v1",
+			"action": "update",
+			"timestamp": "2024-11-23T09:17:42.206Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1180,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10796",
+			"name": "Termet's 47",
+			"action": "update",
+			"timestamp": "2024-11-23T09:17:42.767Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1181,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10797",
+			"name": "Ruby's Ultimate 47",
+			"action": "update",
+			"timestamp": "2024-11-23T09:17:43.316Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1182,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10798",
+			"name": "Witek's Mental Asylum",
+			"action": "update",
+			"timestamp": "2024-11-23T09:17:44.142Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1183,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60788",
+			"name": "Great Berate's Endurance Challenge||Sierra, Termet",
+			"action": "update",
+			"timestamp": "2024-11-23T11:40:19.628Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1184,
+			"userId": "564025785573179407",
+			"model": "Completion",
+			"recordId": "60790",
+			"name": "Nothing To Spare: Quickly Now!||Chokokafe",
+			"action": "create",
+			"timestamp": "2024-11-23T19:20:09.706Z"
+		},
+		{
+			"id": 1185,
+			"userId": "678268257655849000",
+			"model": "Mission",
+			"recordId": "10802",
+			"name": "Brauthem",
+			"action": "create",
+			"timestamp": "2024-11-23T19:34:39.605Z"
+		},
+		{
+			"id": 1186,
+			"userId": "678268257655849000",
+			"model": "Mission",
+			"recordId": "10803",
+			"name": "Jesús",
+			"action": "create",
+			"timestamp": "2024-11-23T19:34:39.615Z"
+		},
+		{
+			"id": 1187,
+			"userId": "678268257655849000",
+			"model": "Mission",
+			"recordId": "10804",
+			"name": "Alejandro",
+			"action": "create",
+			"timestamp": "2024-11-23T19:34:39.631Z"
+		},
+		{
+			"id": 1188,
+			"userId": "678268257655849000",
+			"model": "Mission",
+			"recordId": "10805",
+			"name": "Carlos",
+			"action": "create",
+			"timestamp": "2024-11-23T19:34:39.640Z"
+		},
+		{
+			"id": 1189,
+			"userId": "980292547823931475",
+			"model": "Completion",
+			"recordId": "60791",
+			"name": "Organisation Rush||TylerY2992, Men in Black, Masked Mystery",
+			"action": "create",
+			"timestamp": "2024-11-24T05:39:34.334Z"
+		},
+		{
+			"id": 1190,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60792",
+			"name": "Trial By Fire||BladePL",
+			"action": "create",
+			"timestamp": "2024-11-24T13:15:15.552Z"
+		},
+		{
+			"id": 1191,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10796",
+			"name": "Termet's 47",
+			"action": "update",
+			"timestamp": "2024-11-24T13:44:05.838Z",
+			"before": {},
+			"after": {
+				"bombs": {
+					"update": [
+						{
+							"data": {
+								"time": 6300,
+								"pools": [
+									{ "count": 1, "modules": ["TwennyWan"] },
+									{ "count": 1, "modules": ["AdjacentLettersModule"] },
+									{ "count": 1, "modules": ["answerSmashModule"] },
+									{ "count": 1, "modules": ["Backgrounds"] },
+									{ "count": 1, "modules": ["bamboozledAgain"] },
+									{ "count": 1, "modules": ["bamboozlingButton"] },
+									{ "count": 1, "modules": ["Bowling"] },
+									{ "count": 1, "modules": ["BrailleModule"] },
+									{ "count": 1, "modules": ["BrokenButtonsModule"] },
+									{ "count": 1, "modules": ["catchphrase"] },
+									{ "count": 1, "modules": ["characterShift"] },
+									{ "count": 1, "modules": ["ChordQualities"] },
+									{ "count": 1, "modules": ["Color Decoding"] },
+									{ "count": 1, "modules": ["cruelDigitalRootModule"] },
+									{ "count": 1, "modules": ["CryptModule"] },
+									{ "count": 1, "modules": ["doubleColor"] },
+									{ "count": 1, "modules": ["flashingLights"] },
+									{ "count": 1, "modules": ["forgetMeLater"] },
+									{ "count": 1, "modules": ["MemoryV2"] },
+									{ "count": 1, "modules": ["qkForgetPerspective"] },
+									{ "count": 1, "modules": ["TheGamepadModule"] },
+									{ "count": 1, "modules": ["masyuModule"] },
+									{ "count": 1, "modules": ["modernCipher"] },
+									{ "count": 1, "modules": ["mortalKombat"] },
+									{ "count": 1, "modules": ["MouseInTheMaze"] },
+									{ "count": 1, "modules": ["mysterymodule"] },
+									{ "count": 1, "modules": ["NonogramModule"] },
+									{ "count": 1, "modules": ["NotMaze"] },
+									{ "count": 1, "modules": ["NotMorseCode"] },
+									{ "count": 1, "modules": ["NotWireSequence"] },
+									{ "count": 1, "modules": ["organizationModule"] },
+									{ "count": 1, "modules": ["RegularCrazyTalkModule"] },
+									{ "count": 1, "modules": ["roger"] },
+									{ "count": 1, "modules": ["SetModule"] },
+									{ "count": 1, "modules": ["shikaku"] },
+									{ "count": 1, "modules": ["snooker"] },
+									{ "count": 1, "modules": ["soundDesign"] },
+									{ "count": 1, "modules": ["SouvenirModule"] },
+									{ "count": 1, "modules": ["sphere"] },
+									{ "count": 1, "modules": ["spinningButtons"] },
+									{ "count": 1, "modules": ["stars"] },
+									{ "count": 1, "modules": ["streetFighter"] },
+									{ "count": 1, "modules": ["SuperlogicModule"] },
+									{ "count": 1, "modules": ["tWords"] },
+									{ "count": 1, "modules": ["TextField"] },
+									{ "count": 1, "modules": ["wire"] },
+									{ "count": 1, "modules": ["XRayModule"] }
+								],
+								"modules": 47,
+								"strikes": 10,
+								"widgets": 5
+							},
+							"where": { "id": 14818 }
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 1192,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10796",
+			"name": "Termet's 47",
+			"action": "update",
+			"timestamp": "2024-11-24T13:44:05.858Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=eaaf6c6fdf78aaa31254b47a42694f7e3f56c10b" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=d02d198e8122012d39088547b0f122d729a1cf50" }
+		},
+		{
+			"id": 1193,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60793",
+			"name": "QN!: FCDT||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-24T21:12:43.252Z"
+		},
+		{
+			"id": 1194,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10764",
+			"name": "QN!: FCDT",
+			"action": "update",
+			"timestamp": "2024-11-24T21:12:46.237Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1195,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60793",
+			"name": "QN!: FCDT||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-24T21:12:46.247Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1196,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60794",
+			"name": "Sweet 16||Termet",
+			"action": "create",
+			"timestamp": "2024-11-25T13:43:49.076Z"
+		},
+		{
+			"id": 1197,
+			"userId": "150650873884704769",
+			"model": "Completion",
+			"recordId": "60795",
+			"name": "Extraction (Pt. 2)||AzaFTW, Benjamin, Bianca",
+			"action": "create",
+			"timestamp": "2024-11-25T17:28:59.541Z"
+		},
+		{
+			"id": 1198,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60796",
+			"name": "Awaiting Annihilation||BladePL",
+			"action": "create",
+			"timestamp": "2024-11-25T18:09:56.608Z"
+		},
+		{
+			"id": 1199,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60790",
+			"name": "Nothing To Spare: Quickly Now!||Chokokafe",
+			"action": "update",
+			"timestamp": "2024-11-25T20:26:08.307Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1200,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60790",
+			"name": "Nothing To Spare: Quickly Now!||Chokokafe",
+			"action": "update",
+			"timestamp": "2024-11-25T20:26:28.120Z",
+			"before": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=1a594d74b3a94e7e948813a36193b6136cb123c0;bomb=EK9IV7",
+					"https://media.discordapp.net/attachments/788065461870919700/1309960840136495184/image.png?ex=67437b9a&is=67422a1a&hm=4f5f5f771644ba61f1291e11f27588b9e90a98005bc5c6f1a3f90b72d32338f2&=&format=webp&quality=lossless&width=1440&height=942"
+				]
+			},
+			"after": {
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=1a594d74b3a94e7e948813a36193b6136cb123c0;bomb=EK9IV7"
+				]
+			}
+		},
+		{
+			"id": 1201,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60797",
+			"name": "Maybe a Bomb||Burniel",
+			"action": "create",
+			"timestamp": "2024-11-25T21:33:41.225Z"
+		},
+		{
+			"id": 1202,
+			"userId": "206036413286711297",
+			"model": "Completion",
+			"recordId": "60798",
+			"name": "Ruby's Ultimate 47||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-25T21:57:08.951Z"
+		},
+		{
+			"id": 1203,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10797",
+			"name": "Ruby's Ultimate 47",
+			"action": "update",
+			"timestamp": "2024-11-26T00:30:27.829Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1204,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60798",
+			"name": "Ruby's Ultimate 47||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-26T00:30:27.849Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1205,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60799",
+			"name": "Baka, Baka, Baka||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-26T00:30:42.827Z"
+		},
+		{
+			"id": 1206,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10762",
+			"name": "Baka, Baka, Baka",
+			"action": "update",
+			"timestamp": "2024-11-26T00:30:44.871Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1207,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60799",
+			"name": "Baka, Baka, Baka||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-26T00:30:44.947Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1208,
+			"userId": "594991798045114389",
+			"model": "Completion",
+			"recordId": "60800",
+			"name": "Uber Forget Me Not||Men in Black, Ayeka",
+			"action": "create",
+			"timestamp": "2024-11-26T01:34:33.054Z"
+		},
+		{
+			"id": 1209,
+			"userId": "434345780375977994",
+			"model": "Completion",
+			"recordId": "60801",
+			"name": "Dove||Masked Mystery",
+			"action": "create",
+			"timestamp": "2024-11-26T05:15:24.197Z"
+		},
+		{
+			"id": 1210,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60802",
+			"name": "Step By Step||tactualdwarf519",
+			"action": "create",
+			"timestamp": "2024-11-26T08:51:26.314Z"
+		},
+		{
+			"id": 1211,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60803",
+			"name": "Rendezvous (Pt. 3)||Kugel",
+			"action": "create",
+			"timestamp": "2024-11-26T09:21:16.789Z"
+		},
+		{
+			"id": 1212,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60804",
+			"name": "Supersonic||Kugel",
+			"action": "create",
+			"timestamp": "2024-11-26T11:38:46.492Z"
+		},
+		{
+			"id": 1213,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60805",
+			"name": "17 Again||Termet",
+			"action": "create",
+			"timestamp": "2024-11-26T15:02:01.969Z"
+		},
+		{
+			"id": 1214,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60806",
+			"name": "Veritaserum||Termet, Sierra",
+			"action": "create",
+			"timestamp": "2024-11-26T19:50:02.153Z"
+		},
+		{
+			"id": 1215,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60791",
+			"name": "Organisation Rush||TylerY2992, Men in Black, Masked Mystery",
+			"action": "update",
+			"timestamp": "2024-11-26T20:53:55.146Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1216,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60792",
+			"name": "Trial By Fire||BladePL",
+			"action": "update",
+			"timestamp": "2024-11-26T20:54:23.142Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1217,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60316",
+			"name": "Sweet 16||Termet",
+			"action": "update",
+			"timestamp": "2024-11-26T20:54:46.606Z",
+			"before": {
+				"time": 372.19,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=96c49bf2abda92dac8b317d592229e157f3046d2;bomb=QJ9SS3"
+				]
+			},
+			"after": {
+				"time": 852.44,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=809ece7fcd9c057e56abf6d450f36cc75e73f532;bomb=Z68HJ0"
+				]
+			}
+		},
+		{
+			"id": 1218,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60794",
+			"name": "Sweet 16||Termet",
+			"action": "delete",
+			"timestamp": "2024-11-26T20:54:46.647Z",
+			"before": {
+				"id": 60794,
+				"old": false,
+				"solo": false,
+				"team": ["Termet"],
+				"time": 852.44,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=809ece7fcd9c057e56abf6d450f36cc75e73f532;bomb=Z68HJ0"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-25T13:43:24.610Z",
+				"missionId": 9832,
+				"uploadedBy": "1131645350554390560"
+			}
+		},
+		{
+			"id": 1219,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60795",
+			"name": "Extraction (Pt. 2)||AzaFTW, Benjamin, Bianca",
+			"action": "update",
+			"timestamp": "2024-11-26T20:55:25.636Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1220,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60796",
+			"name": "Awaiting Annihilation||BladePL",
+			"action": "update",
+			"timestamp": "2024-11-26T20:55:58.946Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1221,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60797",
+			"name": "Maybe a Bomb||Burniel",
+			"action": "update",
+			"timestamp": "2024-11-26T20:56:10.537Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1222,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60807",
+			"name": "Symbolophilia||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-26T22:28:43.948Z"
+		},
+		{
+			"id": 1223,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9731",
+			"name": "Symbolophilia",
+			"action": "update",
+			"timestamp": "2024-11-26T22:28:55.478Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1224,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "9731",
+			"name": "Symbolophilia",
+			"action": "update",
+			"timestamp": "2024-11-26T22:28:56.748Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1225,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60807",
+			"name": "Symbolophilia||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-26T22:28:56.787Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1226,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60807",
+			"name": "Symbolophilia||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-26T22:28:56.794Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1227,
+			"userId": "622198629670584330",
+			"model": "Completion",
+			"recordId": "60808",
+			"name": "Impostorous||EricB",
+			"action": "create",
+			"timestamp": "2024-11-27T01:13:35.630Z"
+		},
+		{
+			"id": 1228,
+			"userId": "488046550270869525",
+			"model": "Mission",
+			"recordId": "10806",
+			"name": "The Biscuit",
+			"action": "create",
+			"timestamp": "2024-11-27T01:22:03.498Z"
+		},
+		{
+			"id": 1229,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60809",
+			"name": "Step By Step||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-11-27T07:00:19.742Z"
+		},
+		{
+			"id": 1230,
+			"userId": "208633883544125440",
+			"model": "Mission",
+			"recordId": "10807",
+			"name": "[[UPDATE]] The Rejected Modules",
+			"action": "create",
+			"timestamp": "2024-11-27T18:53:58.750Z"
+		},
+		{
+			"id": 1231,
+			"userId": "980292547823931475",
+			"model": "Completion",
+			"recordId": "60810",
+			"name": "Blank Madness||TylerY2992, Masked Mystery",
+			"action": "create",
+			"timestamp": "2024-11-28T03:45:49.068Z"
+		},
+		{
+			"id": 1232,
+			"userId": "208633883544125440",
+			"model": "Mission",
+			"recordId": "10808",
+			"name": "Elevator Bomb",
+			"action": "create",
+			"timestamp": "2024-11-29T03:16:51.827Z"
+		},
+		{
+			"id": 1233,
+			"userId": "208633883544125440",
+			"model": "Mission",
+			"recordId": "10809",
+			"name": "Hotel Hell",
+			"action": "create",
+			"timestamp": "2024-11-29T03:20:48.174Z"
+		},
+		{
+			"id": 1234,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60811",
+			"name": "Sanguine Arpeggio||Kugel",
+			"action": "create",
+			"timestamp": "2024-11-29T03:50:16.540Z"
+		},
+		{
+			"id": 1235,
+			"userId": "244616599443603456",
+			"model": "Mission",
+			"recordId": "10810",
+			"name": "https://blananas2.github.io/random.html",
+			"action": "create",
+			"timestamp": "2024-11-29T06:03:44.036Z"
+		},
+		{
+			"id": 1236,
+			"userId": "244616599443603456",
+			"model": "Mission",
+			"recordId": "10811",
+			"name": "Not a Bomb",
+			"action": "create",
+			"timestamp": "2024-11-29T06:03:44.046Z"
+		},
+		{
+			"id": 1237,
+			"userId": "244616599443603456",
+			"model": "Mission",
+			"recordId": "10812",
+			"name": "Challenge Bomb Endurance",
+			"action": "create",
+			"timestamp": "2024-11-29T06:03:44.058Z"
+		},
+		{
+			"id": 1238,
+			"userId": "244616599443603456",
+			"model": "Mission",
+			"recordId": "10813",
+			"name": "100 Stage Endurance",
+			"action": "create",
+			"timestamp": "2024-11-29T06:03:44.076Z"
+		},
+		{
+			"id": 1239,
+			"userId": "104464697775882240",
+			"model": "Completion",
+			"recordId": "60812",
+			"name": "Simplifier||Framzo, nameless",
+			"action": "create",
+			"timestamp": "2024-11-29T19:48:29.189Z"
+		},
+		{
+			"id": 1240,
+			"userId": "980292547823931475",
+			"model": "Completion",
+			"recordId": "60813",
+			"name": "An Idol mk2||TylerY2992, Men in Black, Masked Mystery",
+			"action": "create",
+			"timestamp": "2024-11-30T06:11:53.105Z"
+		},
+		{
+			"id": 1241,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10599",
+			"name": "The Rejected Modules",
+			"action": "update",
+			"timestamp": "2024-11-30T12:53:18.346Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=02f1897d9f6407e127a4760c4495c321c3700e37" },
+			"after": {
+				"bombs": {
+					"create": [
+						{
+							"time": 7200,
+							"pools": [
+								{ "count": 1, "modules": ["ALL_VANILLA_NEEDY"] },
+								{ "count": 1, "modules": ["qkBitwiseOblivion"] },
+								{ "count": 1, "modules": ["top10nums"] },
+								{ "count": 1, "modules": ["LOOKATME"] },
+								{ "count": 1, "modules": ["xelMilitaryEncryption"] },
+								{ "count": 1, "modules": ["SapphireButtonModule"] },
+								{ "count": 1, "modules": ["edBalls"] },
+								{ "count": 1, "modules": ["rusticReversal"] },
+								{ "count": 1, "modules": ["blinkingNotes"] },
+								{ "count": 1, "modules": ["Overcooked"] },
+								{ "count": 1, "modules": ["hyperrullo"] },
+								{ "count": 1, "modules": ["xelKeystrokes"] },
+								{ "count": 1, "modules": ["yetAnotherKeypad"] },
+								{ "count": 1, "modules": ["poisonedGoblets"] },
+								{ "count": 1, "modules": ["LightGrid"] },
+								{ "count": 1, "modules": ["lettersAndNumbers"] },
+								{ "count": 1, "modules": ["conditionalMaze"] },
+								{ "count": 1, "modules": ["classicalSense"] },
+								{ "count": 1, "modules": ["nonagonInfinity"] },
+								{ "count": 1, "modules": ["pentrisSprint"] },
+								{ "count": 1, "modules": ["clockCounter"] },
+								{ "count": 1, "modules": ["tangledWires"] },
+								{ "count": 1, "modules": ["megamanBossRush"] },
+								{ "count": 1, "modules": ["mazeCode"] },
+								{ "count": 1, "modules": ["abuttoningMazes"] },
+								{ "count": 1, "modules": ["encryptcore"] },
+								{ "count": 1, "modules": ["SubtractionModule"] },
+								{ "count": 1, "modules": ["turingMachineNightmare"] },
+								{ "count": 1, "modules": ["templatemodule"] },
+								{ "count": 1, "modules": ["strongmadtalker"] },
+								{ "count": 1, "modules": ["solarReorder"] },
+								{ "count": 1, "modules": ["theTeardrop"] },
+								{ "count": 1, "modules": ["repseq"] },
+								{ "count": 1, "modules": ["notAdjacentLettersModule"] },
+								{ "count": 1, "modules": ["cryptid"] },
+								{ "count": 1, "modules": ["facetsAndLogic"] },
+								{ "count": 1, "modules": ["symmetryShuffle"] },
+								{ "count": 1, "modules": ["MultiverseHotline"] },
+								{ "count": 1, "modules": ["GSSatNav"] },
+								{ "count": 1, "modules": ["GSNormalProbability"] },
+								{ "count": 1, "modules": ["karnaugh"] },
+								{ "count": 1, "modules": ["worseCode"] },
+								{ "count": 1, "modules": ["GSGourmetHamburger"] },
+								{ "count": 1, "modules": ["foxedFreshly"] },
+								{ "count": 1, "modules": ["ColorSymbolicInterpretationModule"] },
+								{ "count": 1, "modules": ["NotSaimoeMaze"] },
+								{ "count": 1, "modules": ["polysolver"] }
+							],
+							"modules": 47,
+							"strikes": 5,
+							"widgets": 5
+						}
+					]
+				},
+				"logfile": "https://ktane.timwi.de/lfa#file=8f97e76071a66452512235de3e08883eb423bff0"
+			}
+		},
+		{
+			"id": 1242,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10807",
+			"name": "[[UPDATE]] The Rejected Modules",
+			"action": "delete",
+			"timestamp": "2024-11-30T12:53:18.368Z",
+			"before": {
+				"id": 10807,
+				"name": "[[UPDATE]] The Rejected Modules",
+				"notes": null,
+				"authors": ["Awesome7285"],
+				"factory": null,
+				"logfile": "https://ktane.timwi.de/lfa#file=8f97e76071a66452512235de3e08883eb423bff0",
+				"tpSolve": false,
+				"variant": null,
+				"inGameId": "mod_awesome7285_missions_The Rejected Modules",
+				"timeMode": null,
+				"verified": false,
+				"dateAdded": "2024-11-27T18:52:08.674Z",
+				"inGameName": null,
+				"strikeMode": null,
+				"uploadedBy": "208633883544125440",
+				"designedForTP": false,
+				"missionPackId": 595
+			}
+		},
+		{
+			"id": 1243,
+			"userId": "705094454717186119",
+			"model": "Completion",
+			"recordId": "60814",
+			"name": "A Way Out||BladePL",
+			"action": "create",
+			"timestamp": "2024-11-30T14:00:45.544Z"
+		},
+		{
+			"id": 1244,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60815",
+			"name": "Anamnesis||Sierra",
+			"action": "create",
+			"timestamp": "2024-11-30T15:33:48.349Z"
+		},
+		{
+			"id": 1245,
+			"userId": "192330681987235840",
+			"model": "Completion",
+			"recordId": "60816",
+			"name": "Bravo Echo||Sierra",
+			"action": "create",
+			"timestamp": "2024-11-30T17:12:03.574Z"
+		},
+		{
+			"id": 1246,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60817",
+			"name": "Denial's 1:40||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-30T18:14:05.772Z"
+		},
+		{
+			"id": 1247,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10671",
+			"name": "Denial's 1:40",
+			"action": "update",
+			"timestamp": "2024-11-30T18:14:08.270Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1248,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60817",
+			"name": "Denial's 1:40||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-30T18:14:08.279Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1249,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60818",
+			"name": "Chain Continues||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-11-30T19:10:40.093Z"
+		},
+		{
+			"id": 1250,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10734",
+			"name": "Chain Continues",
+			"action": "update",
+			"timestamp": "2024-11-30T19:10:48.246Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1251,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60818",
+			"name": "Chain Continues||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-11-30T19:10:48.260Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1252,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10814",
+			"name": "[[UPDATE]] Semipseudoquirky",
+			"action": "create",
+			"timestamp": "2024-11-30T23:45:01.597Z"
+		},
+		{
+			"id": 1253,
+			"userId": "118831126239248397",
+			"model": "Completion",
+			"recordId": "60819",
+			"name": "SoulOrg Endurance||denial140, Lyph",
+			"action": "create",
+			"timestamp": "2024-12-01T01:50:55.270Z"
+		},
+		{
+			"id": 1254,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10815",
+			"name": "[[UPDATE]] Cyanturion",
+			"action": "create",
+			"timestamp": "2024-12-01T11:56:53.729Z"
+		},
+		{
+			"id": 1255,
+			"userId": "832703757615497298",
+			"model": "Mission",
+			"recordId": "10816",
+			"name": "[[UPDATE]] Random Chance Cyanturion",
+			"action": "create",
+			"timestamp": "2024-12-01T11:56:53.745Z"
+		},
+		{
+			"id": 1256,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60800",
+			"name": "Uber Forget Me Not||Men in Black, Ayeka",
+			"action": "update",
+			"timestamp": "2024-12-01T12:29:22.167Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1257,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60801",
+			"name": "Dove||Masked Mystery",
+			"action": "update",
+			"timestamp": "2024-12-01T12:30:09.825Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1258,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60802",
+			"name": "Step By Step||tactualdwarf519",
+			"action": "update",
+			"timestamp": "2024-12-01T12:30:38.180Z",
+			"before": { "first": false, "verified": false },
+			"after": { "first": true, "verified": true }
+		},
+		{
+			"id": 1259,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60803",
+			"name": "Rendezvous (Pt. 3)||Kugel",
+			"action": "update",
+			"timestamp": "2024-12-01T12:31:41.163Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1260,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60804",
+			"name": "Supersonic||Kugel",
+			"action": "update",
+			"timestamp": "2024-12-01T12:32:13.375Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1261,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60761",
+			"name": "17 Again||Termet",
+			"action": "update",
+			"timestamp": "2024-12-01T12:33:35.344Z",
+			"before": {
+				"time": 493.33,
+				"proofs": ["https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=21f8fbf57a6b3b51799caf293ad08f0c16b66b6d"]
+			},
+			"after": {
+				"time": 1093.34,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=47c26e225383373e08c6ac97e9b567de14e8ab97;bomb=6V6ZE7"
+				]
+			}
+		},
+		{
+			"id": 1262,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60805",
+			"name": "17 Again||Termet",
+			"action": "delete",
+			"timestamp": "2024-12-01T12:33:35.352Z",
+			"before": {
+				"id": 60805,
+				"old": false,
+				"solo": false,
+				"team": ["Termet"],
+				"time": 1093.34,
+				"first": false,
+				"notes": null,
+				"proofs": [
+					"https://ktane.timwi.de/More/Logfile%20Analyzer.html#file=47c26e225383373e08c6ac97e9b567de14e8ab97;bomb=6V6ZE7"
+				],
+				"verified": false,
+				"dateAdded": "2024-11-26T15:01:45.888Z",
+				"missionId": 9831,
+				"uploadedBy": "1131645350554390560"
+			}
+		},
+		{
+			"id": 1263,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60806",
+			"name": "Veritaserum||Termet, Sierra",
+			"action": "update",
+			"timestamp": "2024-12-01T12:36:07.470Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1264,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60808",
+			"name": "Impostorous||EricB",
+			"action": "update",
+			"timestamp": "2024-12-01T12:36:57.656Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1265,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60809",
+			"name": "Step By Step||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-12-01T12:37:47.634Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1266,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60810",
+			"name": "Blank Madness||TylerY2992, Masked Mystery",
+			"action": "update",
+			"timestamp": "2024-12-01T12:40:43.643Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1267,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60811",
+			"name": "Sanguine Arpeggio||Kugel",
+			"action": "update",
+			"timestamp": "2024-12-01T12:41:11.929Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1268,
+			"userId": "597035767503519765",
+			"model": "Completion",
+			"recordId": "60820",
+			"name": "Just Vibin'||hyeon72",
+			"action": "create",
+			"timestamp": "2024-12-01T15:15:14.190Z"
+		},
+		{
+			"id": 1269,
+			"userId": "1043099159084929024",
+			"model": "Completion",
+			"recordId": "60821",
+			"name": "Centurion||Srećko",
+			"action": "create",
+			"timestamp": "2024-12-01T17:20:44.877Z"
+		},
+		{
+			"id": 1270,
+			"userId": "434345780375977994",
+			"model": "Completion",
+			"recordId": "60822",
+			"name": "Easy Challenge||Masked Mystery, Simao1235",
+			"action": "create",
+			"timestamp": "2024-12-01T17:24:19.858Z"
+		},
+		{
+			"id": 1271,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60823",
+			"name": "Termet's 47||Twitch Plays",
+			"action": "create",
+			"timestamp": "2024-12-01T17:41:50.354Z"
+		},
+		{
+			"id": 1272,
+			"userId": "213189526837919745",
+			"model": "Mission",
+			"recordId": "10796",
+			"name": "Termet's 47",
+			"action": "update",
+			"timestamp": "2024-12-01T17:41:52.755Z",
+			"before": { "tpSolve": false },
+			"after": { "tpSolve": true }
+		},
+		{
+			"id": 1273,
+			"userId": "213189526837919745",
+			"model": "Completion",
+			"recordId": "60823",
+			"name": "Termet's 47||Twitch Plays",
+			"action": "update",
+			"timestamp": "2024-12-01T17:41:52.765Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1274,
+			"userId": "154814006261972992",
+			"model": "Mission",
+			"recordId": "10817",
+			"name": "Golden Cocaine Bear",
+			"action": "create",
+			"timestamp": "2024-12-01T19:28:01.795Z"
+		},
+		{
+			"id": 1275,
+			"userId": "154814006261972992",
+			"model": "Mission",
+			"recordId": "10818",
+			"name": "If It Ain't Broke...",
+			"action": "create",
+			"timestamp": "2024-12-01T19:28:48.420Z"
+		},
+		{
+			"id": 1276,
+			"userId": "154814006261972992",
+			"model": "Mission",
+			"recordId": "10819",
+			"name": "Leap of Faith",
+			"action": "create",
+			"timestamp": "2024-12-01T19:31:44.589Z"
+		},
+		{
+			"id": 1277,
+			"userId": "154814006261972992",
+			"model": "Mission",
+			"recordId": "10820",
+			"name": "One More Time",
+			"action": "create",
+			"timestamp": "2024-12-01T19:34:20.276Z"
+		},
+		{
+			"id": 1278,
+			"userId": "154814006261972992",
+			"model": "Mission",
+			"recordId": "10817",
+			"name": "Golden Cocaine Bear",
+			"action": "update",
+			"timestamp": "2024-12-01T19:38:08.474Z",
+			"before": { "inGameId": "mod_blvd_fish, DisplayNameTerm: mod/blvd_fish_DisplayName" },
+			"after": { "inGameId": "mod_blvd_fish" }
+		},
+		{
+			"id": 1279,
+			"userId": "467065763342319616",
+			"model": "Completion",
+			"recordId": "60824",
+			"name": "SoulOrg Endurance||Masked Mystery, Simao1235",
+			"action": "create",
+			"timestamp": "2024-12-02T00:29:12.773Z"
+		},
+		{
+			"id": 1280,
+			"userId": "455035517872898050",
+			"model": "Mission",
+			"recordId": "10821",
+			"name": "Talking 'Bout Regeneration",
+			"action": "create",
+			"timestamp": "2024-12-02T14:56:39.907Z"
+		},
+		{
+			"id": 1281,
+			"userId": "455035517872898050",
+			"model": "Mission",
+			"recordId": "10822",
+			"name": "_Play_'s Sillier Favourites",
+			"action": "create",
+			"timestamp": "2024-12-02T14:56:39.922Z"
+		},
+		{
+			"id": 1282,
+			"userId": "455035517872898050",
+			"model": "Mission",
+			"recordId": "10823",
+			"name": "Set Up Madness",
+			"action": "create",
+			"timestamp": "2024-12-02T14:56:39.938Z"
+		},
+		{
+			"id": 1283,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60825",
+			"name": "Easy Bomb||Termet",
+			"action": "create",
+			"timestamp": "2024-12-02T16:59:57.979Z"
+		},
+		{
+			"id": 1284,
+			"userId": "486602438103531520",
+			"model": "Mission",
+			"recordId": "10823",
+			"name": "Set Up Madness",
+			"action": "update",
+			"timestamp": "2024-12-02T18:04:36.676Z",
+			"before": { "notes": null },
+			"after": { "notes": "Several modules have mission config applied - see mission description" }
+		},
+		{
+			"id": 1285,
+			"userId": "1131645350554390560",
+			"model": "Completion",
+			"recordId": "60826",
+			"name": "Baking Soda||Termet",
+			"action": "create",
+			"timestamp": "2024-12-02T22:26:14.033Z"
+		},
+		{
+			"id": 1286,
+			"userId": "459108669636739072",
+			"model": "Completion",
+			"recordId": "60827",
+			"name": "Fnuuy||Kugel",
+			"action": "create",
+			"timestamp": "2024-12-03T09:01:04.676Z"
+		},
+		{
+			"id": 1287,
+			"userId": "154814006261972992",
+			"model": "Completion",
+			"recordId": "60812",
+			"name": "Simplifier||Framzo, nameless",
+			"action": "update",
+			"timestamp": "2024-12-03T18:10:20.924Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1288,
+			"userId": "154814006261972992",
+			"model": "Completion",
+			"recordId": "60815",
+			"name": "Anamnesis||Sierra",
+			"action": "update",
+			"timestamp": "2024-12-03T18:21:32.389Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1289,
+			"userId": "154814006261972992",
+			"model": "Completion",
+			"recordId": "60816",
+			"name": "Bravo Echo||Sierra",
+			"action": "update",
+			"timestamp": "2024-12-03T18:28:10.416Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1290,
+			"userId": "154814006261972992",
+			"model": "Completion",
+			"recordId": "60819",
+			"name": "SoulOrg Endurance||denial140, Lyph",
+			"action": "update",
+			"timestamp": "2024-12-03T18:30:03.146Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1291,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10646",
+			"name": "Triple Trouble",
+			"action": "update",
+			"timestamp": "2024-12-03T21:45:11.571Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=76f6ee3a667722ab9672de9723879ee901712c43" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=3729fd51038e6ee0d556a1d9e341a2d98341fc6f" }
+		},
+		{
+			"id": 1292,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10646",
+			"name": "Triple Trouble",
+			"action": "update",
+			"timestamp": "2024-12-03T21:46:07.471Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=3729fd51038e6ee0d556a1d9e341a2d98341fc6f" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=76f6ee3a667722ab9672de9723879ee901712c43" }
+		},
+		{
+			"id": 1293,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10796",
+			"name": "Termet's 47",
+			"action": "update",
+			"timestamp": "2024-12-03T21:46:41.539Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=d02d198e8122012d39088547b0f122d729a1cf50" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=3729fd51038e6ee0d556a1d9e341a2d98341fc6f" }
+		},
+		{
+			"id": 1294,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10796",
+			"name": "Termet's 47",
+			"action": "update",
+			"timestamp": "2024-12-03T21:47:17.870Z",
+			"before": { "inGameId": "mod_toc_HexiAdvancedBaseModules_0_SectionTitle_3: \"Complex Contraptions\"" },
+			"after": { "inGameId": "mod_mibsion_pack_Termet's 47" }
+		},
+		{
+			"id": 1295,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10783",
+			"name": "Step By Step",
+			"action": "update",
+			"timestamp": "2024-12-03T21:50:56.219Z",
+			"before": { "inGameId": "mod_toc_HexiAdvancedBaseModules_0_SectionTitle_3: \"Complex Contraptions\"" },
+			"after": { "inGameId": "mod_bombesDeFrance_sidStep" }
+		},
+		{
+			"id": 1296,
+			"userId": "688220820945895424",
+			"model": "Mission",
+			"recordId": "10783",
+			"name": "Step By Step",
+			"action": "update",
+			"timestamp": "2024-12-03T21:52:14.427Z",
+			"before": { "logfile": "https://ktane.timwi.de/lfa#file=0e0b2949f27917a76511d1ea2720001ad5bef75c" },
+			"after": { "logfile": "https://ktane.timwi.de/lfa#file=bb663d457967def5810b86e325ae8bda44050bc1" }
+		},
+		{
+			"id": 1297,
+			"userId": "349646830012727296",
+			"model": "Completion",
+			"recordId": "60828",
+			"name": "Reasonable||tactualdwarf519, GreatQuestion",
+			"action": "create",
+			"timestamp": "2024-12-04T03:14:36.920Z"
+		},
+		{
+			"id": 1298,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60813",
+			"name": "An Idol mk2||TylerY2992, Men in Black, Masked Mystery",
+			"action": "update",
+			"timestamp": "2024-12-04T08:17:50.289Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1299,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60814",
+			"name": "A Way Out||BladePL",
+			"action": "update",
+			"timestamp": "2024-12-04T08:18:06.845Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1300,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60820",
+			"name": "Just Vibin'||hyeon72",
+			"action": "update",
+			"timestamp": "2024-12-04T08:18:23.035Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1301,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60821",
+			"name": "Centurion||Srećko",
+			"action": "update",
+			"timestamp": "2024-12-04T08:18:49.211Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1302,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60822",
+			"name": "Easy Challenge||Masked Mystery, Simao1235",
+			"action": "update",
+			"timestamp": "2024-12-04T08:19:17.217Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1303,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60824",
+			"name": "SoulOrg Endurance||Masked Mystery, Simao1235",
+			"action": "update",
+			"timestamp": "2024-12-04T08:19:34.962Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1304,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60825",
+			"name": "Easy Bomb||Termet",
+			"action": "update",
+			"timestamp": "2024-12-04T08:22:09.731Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1305,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60826",
+			"name": "Baking Soda||Termet",
+			"action": "update",
+			"timestamp": "2024-12-04T08:23:50.705Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1306,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60827",
+			"name": "Fnuuy||Kugel",
+			"action": "update",
+			"timestamp": "2024-12-04T08:24:53.034Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
+		},
+		{
+			"id": 1307,
+			"userId": "486602438103531520",
+			"model": "Completion",
+			"recordId": "60828",
+			"name": "Reasonable||tactualdwarf519, GreatQuestion",
+			"action": "update",
+			"timestamp": "2024-12-04T08:25:15.236Z",
+			"before": { "verified": false },
+			"after": { "verified": true }
 		}
 	],
 	"User": [
@@ -10225,7 +19873,7 @@
 			"id": "1011677831295684742",
 			"username": "Mr. Punchy",
 			"discordName": "mr.punchymobile",
-			"avatar": "c809bc18ec578a94150b3ebcc069f541",
+			"avatar": "4c5f4d7cacff2ff8b450f0a1018fb344",
 			"permissions": []
 		},
 		{
@@ -10253,7 +19901,7 @@
 			"id": "104464697775882240",
 			"username": "Framzo",
 			"discordName": "framzo",
-			"avatar": "856648d301cbd785d86732c1d7d7d622",
+			"avatar": "001709de99e26c0870ab6948a17dcab2",
 			"permissions": []
 		},
 		{
@@ -10373,7 +20021,7 @@
 			"id": "1131645350554390560",
 			"username": "Termet",
 			"discordName": "termetreum",
-			"avatar": "13277c05c4a659bb0074b2c1b69e09a4",
+			"avatar": "01db96be9e1c40587c4c0a9a99e9ff79",
 			"permissions": []
 		},
 		{
@@ -10408,7 +20056,14 @@
 			"id": "1179187768048504902",
 			"username": "Yoshi Dojo",
 			"discordName": "yoshidojostamps87",
-			"avatar": "72009872bf47ef7bce6d22225b49b25a",
+			"avatar": "774c5587fedc79c04295028cb5b97cdf",
+			"permissions": []
+		},
+		{
+			"id": "1187320478927429646",
+			"username": "noah2009",
+			"discordName": "noah2009010101",
+			"avatar": "69523f5281e33e06f71c43fa3bcf18f4",
 			"permissions": []
 		},
 		{
@@ -10471,7 +20126,14 @@
 			"id": "1257674411700523131",
 			"username": "Pararadox",
 			"discordName": "_pararadox",
-			"avatar": "f7676168f241205d33e7daf8245d369f",
+			"avatar": "c78f1833dd096e2535d04c0b993eec25",
+			"permissions": []
+		},
+		{
+			"id": "1276994663714390039",
+			"username": "Cyanix",
+			"discordName": "cyanixdash",
+			"avatar": "c8e288da5bbb8058019de35cab4bb0ac",
 			"permissions": []
 		},
 		{
@@ -10493,6 +20155,13 @@
 			"username": "haz",
 			"discordName": "haz429",
 			"avatar": "f4d67b27a78b67fd3cafa8adeff0f39b",
+			"permissions": []
+		},
+		{
+			"id": "133278904772329472",
+			"username": "MarioXTurn",
+			"discordName": "marioxturn",
+			"avatar": "c28b604aac3c345ccf4babc5677199eb",
 			"permissions": []
 		},
 		{
@@ -10542,7 +20211,7 @@
 			"id": "154814006261972992",
 			"username": "BlvdBroken",
 			"discordName": "blvdbroken",
-			"avatar": "9dcbe53d218ad0465723521bccbe5903",
+			"avatar": "5f63977c4345293a813fa537841270ee",
 			"permissions": [1, 2, 3, 4]
 		},
 		{
@@ -10710,7 +20379,7 @@
 			"id": "198971491398713345",
 			"username": "VFlyer",
 			"discordName": "vflyer",
-			"avatar": "96a0968eb40906f7561e42d97bd0a8bf",
+			"avatar": "49c52aa4788f54a4535056d109312e75",
 			"permissions": []
 		},
 		{
@@ -10718,6 +20387,13 @@
 			"username": "comparestore",
 			"discordName": "comparestore",
 			"avatar": "7909b68c2a05d1341e5f973e9f974ec6",
+			"permissions": []
+		},
+		{
+			"id": "206036413286711297",
+			"username": "duperhero",
+			"discordName": "duperhero",
+			"avatar": "79a520defe6d1a6eefd8362ef04c95ed",
 			"permissions": []
 		},
 		{
@@ -10780,7 +20456,7 @@
 			"id": "213189526837919745",
 			"username": "Crazycaleb",
 			"discordName": "crazycaleb",
-			"avatar": "8c82bb3c2ee1902eca6b5e90aafa9ea5",
+			"avatar": "f8403e652016042fee323c2f170a43fa",
 			"permissions": [1, 2, 3, 4]
 		},
 		{
@@ -10871,7 +20547,7 @@
 			"id": "234733182442799104",
 			"username": "Danielstigman",
 			"discordName": "danielstigman",
-			"avatar": "0c8f84ebc0b29bad2b881161bc2dec76",
+			"avatar": "da65c49115eb3552c0c60e61a2f219a1",
 			"permissions": []
 		},
 		{
@@ -11053,7 +20729,7 @@
 			"id": "265157644300320769",
 			"username": "NShep",
 			"discordName": "nshep98",
-			"avatar": "38117b1e5c11cdd5d3ac5c0627cc4b0e",
+			"avatar": "63c0f5c46f38b574b17e463fa59738ae",
 			"permissions": []
 		},
 		{
@@ -11095,7 +20771,7 @@
 			"id": "272958683070201856",
 			"username": "bioplay",
 			"discordName": "bioplay",
-			"avatar": "fe9160946650d6c1ab56a2484e853769",
+			"avatar": "800b11d300d74bf2bc32f055444ffbe9",
 			"permissions": [1, 2, 3, 4]
 		},
 		{
@@ -11529,7 +21205,7 @@
 			"id": "370356150350249984",
 			"username": "Aaron Kitty Boiii",
 			"discordName": "aaronkittyboiii",
-			"avatar": "043c1173db91ad7b3fb083930e53b0ba",
+			"avatar": "13aa5f07f142ce2a442af0ac4a1311a6",
 			"permissions": []
 		},
 		{
@@ -11666,6 +21342,13 @@
 			"permissions": [1, 2, 3, 4]
 		},
 		{
+			"id": "413975625351561216",
+			"username": "Lightbulb",
+			"discordName": "1ightbulb",
+			"avatar": "47ea3ff2f7b9deddc5012b0aeed67bca",
+			"permissions": []
+		},
+		{
 			"id": "420148465121755137",
 			"username": "226PHIL",
 			"discordName": "226phil",
@@ -11778,6 +21461,13 @@
 			"permissions": []
 		},
 		{
+			"id": "467065763342319616",
+			"username": "Simao1235",
+			"discordName": "simao1235",
+			"avatar": "f29e5b7af7b7f40d213049b07c52c853",
+			"permissions": []
+		},
+		{
 			"id": "468634032809443329",
 			"username": "PsychoGirl",
 			"discordName": "psychogirl1508",
@@ -11844,7 +21534,7 @@
 			"id": "485774478282981376",
 			"username": "weird",
 			"discordName": "weird_th",
-			"avatar": "279ffa7991816ea52fef21330820585e",
+			"avatar": "c6582f67fd572715e84f8c5ecaa3dd1f",
 			"permissions": []
 		},
 		{
@@ -11865,7 +21555,7 @@
 			"id": "488046550270869525",
 			"username": "Tachatat",
 			"discordName": "tachudf",
-			"avatar": "3fed94badfec09b5be17ace689fab4f2",
+			"avatar": "327cfad81772807b15870042ea7be659",
 			"permissions": []
 		},
 		{
@@ -11912,6 +21602,13 @@
 			"permissions": []
 		},
 		{
+			"id": "505651416308776960",
+			"username": "sirietta03",
+			"discordName": "sirietta03",
+			"avatar": "7dccb6a5ec803aaaf7491fc949d4c385",
+			"permissions": []
+		},
+		{
 			"id": "505793920928710657",
 			"username": "Gekki",
 			"discordName": "gekki.jb",
@@ -11930,6 +21627,13 @@
 			"username": "Ugh_Sunlight",
 			"discordName": "Ugh_Sunlight#7464",
 			"avatar": "ba76290a9fad1eecdf9ce2c2eaab0f3d",
+			"permissions": []
+		},
+		{
+			"id": "515919551444025407",
+			"username": "Ekmek",
+			"discordName": "tonkoopman",
+			"avatar": "968a7764e2ab1e4a68a543ab32aa21e4",
 			"permissions": []
 		},
 		{
@@ -11978,7 +21682,7 @@
 			"id": "543151254323331077",
 			"username": "Millie-Rose",
 			"discordName": "rosenothorns03",
-			"avatar": "1ad34e36086e8a9d0edfc1ed56f6df26",
+			"avatar": "686186f751a370d94c7a2ee79f7b4cfd",
 			"permissions": []
 		},
 		{
@@ -12045,6 +21749,13 @@
 			"permissions": []
 		},
 		{
+			"id": "589237691691040798",
+			"username": "LitAiden",
+			"discordName": "slowly.dying.inside",
+			"avatar": "54a03e3b058ebca81ca9db8616beffd4",
+			"permissions": []
+		},
+		{
 			"id": "594991798045114389",
 			"username": "Ayeka",
 			"discordName": "ayekareads",
@@ -12093,7 +21804,13 @@
 			"avatar": "3bd10a92b6d6d69e1b80e284a38f940b",
 			"permissions": []
 		},
-		{ "id": "622198629670584330", "username": "EricB", "discordName": "ericb_2536", "avatar": "0", "permissions": [] },
+		{
+			"id": "622198629670584330",
+			"username": "EricB",
+			"discordName": "ericb_2536",
+			"avatar": "913f77723abf5b05936e8cad17b96d44",
+			"permissions": []
+		},
 		{
 			"id": "625778831004794890",
 			"username": "3xp3rtz",
@@ -12105,7 +21822,7 @@
 			"id": "628939105480474636",
 			"username": "TheBigBadBull",
 			"discordName": ".thebigbadbull",
-			"avatar": "6d8b46a3d177d61d85a582d599a8827f",
+			"avatar": "39236144b150edf683b7fed14b08a89e",
 			"permissions": []
 		},
 		{
@@ -12126,7 +21843,7 @@
 			"id": "649278621550116864",
 			"username": "Lily",
 			"discordName": "lilyflair",
-			"avatar": "e16c0c3016dc2433d3aa8e04a888d6c1",
+			"avatar": "a33917befbc79348b06298987bd0d3f0",
 			"permissions": []
 		},
 		{
@@ -12179,10 +21896,17 @@
 			"permissions": []
 		},
 		{
+			"id": "680029886257299517",
+			"username": "walmartmagnus",
+			"discordName": "walmartmagnus",
+			"avatar": "f58973ad96a3a662fd01e1a43826dd65",
+			"permissions": []
+		},
+		{
 			"id": "682468566947332118",
 			"username": "BorisP",
 			"discordName": ".borisp1014",
-			"avatar": "edcb53baa98102b72d71888b35661974",
+			"avatar": "44f98b63607e5531e0cea286fa54d74d",
 			"permissions": []
 		},
 		{
@@ -12202,7 +21926,7 @@
 		{
 			"id": "689219553531658292",
 			"username": "Faith",
-			"discordName": "faiththefemboy",
+			"discordName": "faith21272",
 			"avatar": "67c7582e73f7b03814ae067c6d76bf7b",
 			"permissions": []
 		},
@@ -12345,6 +22069,13 @@
 			"username": "redpenguiin",
 			"discordName": "redpenguiin#0",
 			"avatar": "9e3dc27fdef2d9df8e42dca8e5f2f14e",
+			"permissions": []
+		},
+		{
+			"id": "734522622527668246",
+			"username": "Requiem",
+			"discordName": "6requiem",
+			"avatar": "bbf20c1685cfab94d5a4e93bc52b709e",
 			"permissions": []
 		},
 		{
@@ -12498,7 +22229,7 @@
 			"id": "832703757615497298",
 			"username": "Axodeau",
 			"discordName": "axodeau",
-			"avatar": "29c0c82a6ab035f35dd4339f0626365c",
+			"avatar": "4bd12f6bf12f25e6e3c7b088f5eb08c1",
 			"permissions": []
 		},
 		{

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -385,8 +385,11 @@ export function validateLogfileLink(link: string): string | boolean {
 }
 
 export function validateMissionID(id: string): string | boolean {
-	if (id !== null && !id.match(/mod_(.+?)_(.+)/)) {
-		return 'format expected: mod_missionPackId_missionId';
+	if (id === null || !id.match(/mod_(.+?)_(.+)/)) {
+		return 'This is the mission ID string from Unity. Format expected: mod_missionPackId_missionId';
+	}
+	if (id.match(/mod_toc_(.+)/i)) {
+		return 'That ID is invalid';
 	}
 	return true;
 }

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -5,6 +5,12 @@
 	<h1 class="header">What’s New?</h1>
 </div>
 <div class="block update">
+	<h3>15 December 2024</h3>
+	<ul>
+		<li>Improved logfile parsing for Mission ID string. Now ignores <code>mod_toc_*</code> text.</li>
+	</ul>
+</div>
+<div class="block update">
 	<h3>18 October 2024</h3>
 	<ul>
 		<li>New endpoint <a href="/json/missionpacks">Mission Packs</a></li>

--- a/src/routes/upload/_MissionPackSection.svelte
+++ b/src/routes/upload/_MissionPackSection.svelte
@@ -11,15 +11,23 @@
 		dateAdded: new Date()
 	};
 
-	let invalid = false;
+	let idInvalid = false;
+	let nameInvalid = false;
 	let valid = false;
 	let inputtedId = '';
 	$: {
 		pack.steamId = getSteamID(inputtedId);
-		valid = !invalid && pack.name.length > 0 && pack.steamId.length > 0;
+		valid = !idInvalid && !nameInvalid && pack.name.length > 0 && pack.steamId.length > 0;
+	}
+
+	function validateMissionPackName(str: string): string | boolean {
+		if (str.toLowerCase() === 'toc') return 'That name is not allowed';
+		else if (str.trim().length < 1) return 'Name must not be blank';
+		return true;
 	}
 
 	function upload() {
+		pack.name = pack.name.trim();
 		fetch('/upload/missionpack', {
 			method: 'POST',
 			headers: {
@@ -43,13 +51,19 @@
 </script>
 
 <div class="block flex grow">
-	<Input label="Name" id="pack-name" required bind:value={pack.name} />
+	<Input
+		label="Name"
+		id="pack-name"
+		validate={validateMissionPackName}
+		required
+		bind:invalid={nameInvalid}
+		bind:value={pack.name} />
 	<Input
 		label="Steam ID / Workshop URL"
 		id="pack-steam-id"
 		validate={validateSteamID}
 		required
-		bind:invalid
+		bind:invalid={idInvalid}
 		bind:value={inputtedId} />
 </div>
 <div class="block">

--- a/src/routes/upload/_MissionSection.svelte
+++ b/src/routes/upload/_MissionSection.svelte
@@ -185,7 +185,20 @@
 </script>
 
 <div class="block flex column">
-	<div>Select a logfile that contains the mission to upload.</div>
+	<div>Paste a logfile link that contains the mission to upload.</div>
+	<div>To obtain a perfect logfile containing all the info the site needs:</div>
+	<ol>
+		<li>Open the mission in the game, wait for all modules to load.</li>
+		<li>
+			Detonate the bomb. Using the <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=1419312202"
+				>command line</a> <code>detonate</code> command is prefered because it doesn't create strikes in the logfile, but
+			you can also strike out on the bomb to generate an acceptable logfile.
+		</li>
+		<li>
+			Use the <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=1358839759">logfile upload hotkey</a> to obtain
+			the logfile link.
+		</li>
+	</ol>
 	<Input
 		label="Logfile link:"
 		id="logfile-link"

--- a/src/routes/upload/_MissionSection.svelte
+++ b/src/routes/upload/_MissionSection.svelte
@@ -36,7 +36,7 @@
 		let mission: ReplaceableMission | null = null;
 		let bomb: Bomb | null = null;
 		let lineIndex = 0;
-		const lines = text.split('\n').map(line => line.length > 20000 ? "" : line);
+		const lines = text.split('\n').map(line => (line.length > 20000 ? '' : line));
 
 		function readLine() {
 			return lines[lineIndex++];
@@ -44,7 +44,8 @@
 
 		while (lineIndex < lines.length) {
 			let line = readLine().trim();
-			let modIdMatch = line.match(/.*?(mod_.+)/);
+			let modIdMatch =
+				line.match(/.*?(mod_.+_.+)/) && !line.match(/.*?(mod_toc_.+)/) ? line.match(/.*?(mod_.+)/) : null;
 			if (modIdMatch !== null && mission !== null) {
 				if (!mission.ids.includes(modIdMatch[1])) mission.ids.push(modIdMatch[1]);
 				mission.inGameId = modIdMatch[1];
@@ -246,6 +247,8 @@
 							options={mission.ids}
 							optionalOptions
 							bind:value={mission.inGameId}
+							placeholder="mod_missionPackId_missionId"
+							instantFormat={false}
 							required={selectedMissions[i]} />
 						{#if mission.bombs.length > 1}
 							<div class="flex grow hspace">


### PR DESCRIPTION
1. The upload mission page now ignores `mod_toc_*` text from the logfiles, since this is never the mission ID string.
2. It also shows an error message when the format is invalid or if the entered text matches the `mod_toc_*` format
![image](https://github.com/user-attachments/assets/52af95b4-1632-4cd0-8bbd-af050ec04557)
![image](https://github.com/user-attachments/assets/8d20ee2e-eeb9-4a5a-a973-a8fbac4509f7)
3. Mission pack names are not allowed to be only the letters "toc" from now on, to prevent conflicts with this new check.
![image](https://github.com/user-attachments/assets/fe839ea3-154b-472d-98d6-c2a3269baa46)
4. Added instructions on the Upload Mission section for how to obtain an ideal logfile for uploading a mission.
![image](https://github.com/user-attachments/assets/69032ccb-64ec-4ae0-b99f-6f95cb28221b)
